### PR TITLE
Add transient mapping annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ annotation | level | description
 @Key | field | stores the field as the system field _key
 @Rev | field | stores the field as the system field _rev
 @Field("alt-name") | field | stores the field with an alternative name
+@Transient | field | does not store the field
 @Ref | field | stores the _id of the referenced document and not the nested document
 @From | field | stores the _id of the referenced document as the system field _from
 @To | field | stores the _id of the referenced document as the system field _to

--- a/src/main/java/com/arangodb/springframework/annotation/Transient.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Transient.java
@@ -1,0 +1,36 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2017 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Christian Lechner
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface Transient {
+
+}

--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
@@ -58,6 +58,7 @@ import com.arangodb.velocypack.VPackSlice;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class DefaultArangoConverter implements ArangoConverter {
@@ -358,7 +359,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 
 	@SuppressWarnings("unchecked")
 	private void writeProperty(final Object source, final DBEntity sink, final ArangoPersistentProperty property) {
-		if (source == null) {
+		if (source == null || property.isTransient()) {
 			return;
 		}
 		final String fieldName = property.getFieldName();

--- a/src/main/java/com/arangodb/springframework/core/mapping/DefaultArangoPersistentProperty.java
+++ b/src/main/java/com/arangodb/springframework/core/mapping/DefaultArangoPersistentProperty.java
@@ -43,9 +43,11 @@ import com.arangodb.springframework.annotation.Relations;
 import com.arangodb.springframework.annotation.Rev;
 import com.arangodb.springframework.annotation.SkiplistIndexed;
 import com.arangodb.springframework.annotation.To;
+import com.arangodb.springframework.annotation.Transient;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class DefaultArangoPersistentProperty extends AnnotationBasedPersistentProperty<ArangoPersistentProperty>
@@ -74,6 +76,11 @@ public class DefaultArangoPersistentProperty extends AnnotationBasedPersistentPr
 	@Override
 	public boolean isRevProperty() {
 		return findAnnotation(Rev.class) != null;
+	}
+
+	@Override
+	public boolean isTransient() {
+		return findAnnotation(Transient.class) != null;
 	}
 
 	@Override

--- a/src/test/java/com/arangodb/springframework/core/mapping/ArangoMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/ArangoMappingTest.java
@@ -55,11 +55,13 @@ import com.arangodb.springframework.annotation.Ref;
 import com.arangodb.springframework.annotation.Relations;
 import com.arangodb.springframework.annotation.Rev;
 import com.arangodb.springframework.annotation.To;
+import com.arangodb.springframework.annotation.Transient;
 import com.arangodb.util.MapBuilder;
 import com.arangodb.velocypack.VPackSlice;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -148,6 +150,22 @@ public class ArangoMappingTest extends AbstractArangoTest {
 		assertThat(slice, is(notNullValue()));
 		assertThat(slice.get("alt-test").isString(), is(true));
 		assertThat(slice.get("alt-test").getAsString(), is(entity.test));
+	}
+
+	public static class TransientFieldTestEntity extends BasicTestEntity {
+		@Transient
+		private String test;
+	}
+
+	@Test
+	public void transientAnnotation() {
+		final TransientFieldTestEntity entity = new TransientFieldTestEntity();
+		entity.test = "1234";
+		final DocumentEntity res = template.insert(entity);
+		final VPackSlice slice = template.driver().db(ArangoTestConfiguration.DB).getDocument(res.getId(),
+			VPackSlice.class);
+		assertThat(slice, is(notNullValue()));
+		assertThat(slice.get("test").isNone(), is(true));
 	}
 
 	public static class SingleNestedDocumentTestEntity extends BasicTestEntity {


### PR DESCRIPTION
Add additional `@Transient` mapping annotation. Fields annotated with `@Transient` are not persisted to the DB.