### PR TITLE
Add DataIntegrityViolationException to ExceptionTranslator

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/util/ArangoErrors.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoErrors.java
@@ -22,6 +22,7 @@ package com.arangodb.springframework.core.util;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class ArangoErrors {
@@ -50,6 +51,11 @@ public class ArangoErrors {
 	 * method not supported. Will be raised when an unsupported HTTP method is used for an operation.
 	 */
 	public static final int ERROR_HTTP_METHOD_NOT_ALLOWED = 405;
+
+	/**
+	 * conflict. Will be raised when a conflict is encountered.
+	 */
+	public static final int ERROR_HTTP_CONFLICT = 409;
 
 	/**
 	 * precondition failed. Will be raised when a precondition for an HTTP request is not met.

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
@@ -22,6 +22,7 @@ package com.arangodb.springframework.core.util;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.dao.PermissionDeniedDataAccessException;
@@ -32,6 +33,7 @@ import com.arangodb.springframework.ArangoUncategorizedException;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class ArangoExceptionTranslator implements PersistenceExceptionTranslator {
@@ -56,6 +58,9 @@ public class ArangoExceptionTranslator implements PersistenceExceptionTranslator
 					break;
 				case ArangoErrors.ERROR_HTTP_NOT_FOUND:
 					dae = new InvalidDataAccessResourceUsageException(exception.getMessage(), exception);
+					break;
+				case ArangoErrors.ERROR_HTTP_CONFLICT:
+					dae = new DataIntegrityViolationException(exception.getMessage(), exception);
 					break;
 				case ArangoErrors.ERROR_HTTP_PRECONDITION_FAILED:
 				case ArangoErrors.ERROR_HTTP_SERVICE_UNAVAILABLE:


### PR DESCRIPTION
Translate HTTP Status Code `409 - Conflict` to `DataIntegrityViolationException`. Happens e.g. on unique constraint violations.