### PR TITLE
minor changes to insert and query template methods

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -75,7 +75,8 @@ public interface ArangoOperations {
 	 * @return cursor of the results
 	 * @throws DataAccessException
 	 */
-	<T> ArangoCursor<T> query(String query, Map<String, Object> bindVars, AqlQueryOptions options, Class<T> entityClass) throws DataAccessException;
+	<T> ArangoCursor<T> query(String query, Map<String, Object> bindVars, AqlQueryOptions options, Class<T> entityClass)
+			throws DataAccessException;
 
 	/**
 	 * Create a cursor and return the first results. For queries without bind parameters.
@@ -103,7 +104,10 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass, DocumentDeleteOptions options) throws DataAccessException;
+	MultiDocumentEntity<? extends DocumentEntity> delete(
+		Iterable<Object> values,
+		Class<?> entityClass,
+		DocumentDeleteOptions options) throws DataAccessException;
 
 	/**
 	 * Removes multiple document
@@ -115,7 +119,8 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass) throws DataAccessException;
+	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass)
+			throws DataAccessException;
 
 	/**
 	 * Removes a document
@@ -160,7 +165,10 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass, DocumentUpdateOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> update(
+		Iterable<T> values,
+		Class<T> entityClass,
+		DocumentUpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Partially updates documents, the documents to update are specified by the _key attributes in the objects on
@@ -177,7 +185,8 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass)
+			throws DataAccessException;
 
 	/**
 	 * Partially updates the document identified by document id or key. The value must contain a document with the
@@ -224,7 +233,10 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass, DocumentReplaceOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> replace(
+		Iterable<T> values,
+		Class<T> entityClass,
+		DocumentReplaceOptions options) throws DataAccessException;
 
 	/**
 	 * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
@@ -241,7 +253,8 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass)
+			throws DataAccessException;
 
 	/**
 	 * Replaces the document with key with the one in the body, provided there is such a document and no precondition is
@@ -312,7 +325,10 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass, DocumentCreateOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> insert(
+		Iterable<T> values,
+		Class<T> entityClass,
+		DocumentCreateOptions options) throws DataAccessException;
 
 	/**
 	 * Creates new documents from the given documents, unless there is already a document with the _key given. If no
@@ -327,7 +343,8 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass)
+			throws DataAccessException;
 
 	/**
 	 * Creates a new document from the given document, unless there is already a document with the _key given. If no
@@ -364,7 +381,8 @@ public interface ArangoOperations {
 	 * @return information about the document
 	 * @throws DataAccessException
 	 */
-	DocumentEntity insert(String collectionName, Object value, DocumentCreateOptions options) throws DataAccessException;
+	DocumentEntity insert(String collectionName, Object value, DocumentCreateOptions options)
+			throws DataAccessException;
 
 	/**
 	

--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -67,7 +67,7 @@ public interface ArangoOperations {
 	 * @param query
 	 *            contains the query string to be executed
 	 * @param bindVars
-	 *            key/value pairs representing the bind parameters
+	 *            key/value pairs representing the bind parameters, can be null
 	 * @param options
 	 *            Additional options, can be null
 	 * @param entityClass
@@ -75,8 +75,21 @@ public interface ArangoOperations {
 	 * @return cursor of the results
 	 * @throws DataAccessException
 	 */
-	<T> ArangoCursor<T> query(String query, Map<String, Object> bindVars, AqlQueryOptions options, Class<T> entityClass)
-			throws DataAccessException;
+	<T> ArangoCursor<T> query(String query, Map<String, Object> bindVars, AqlQueryOptions options, Class<T> entityClass) throws DataAccessException;
+
+	/**
+	 * Create a cursor and return the first results. For queries without bind parameters.
+	 * 
+	 * @param query
+	 *            contains the query string to be executed
+	 * @param options
+	 *            Additional options, can be null
+	 * @param entityClass
+	 *            The entity type of the result
+	 * @return cursor of the results
+	 * @throws DataAccessException
+	 */
+	<T> ArangoCursor<T> query(String query, AqlQueryOptions options, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Removes multiple document
@@ -90,10 +103,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	MultiDocumentEntity<? extends DocumentEntity> delete(
-		Iterable<Object> values,
-		Class<?> entityClass,
-		DocumentDeleteOptions options) throws DataAccessException;
+	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass, DocumentDeleteOptions options) throws DataAccessException;
 
 	/**
 	 * Removes multiple document
@@ -105,8 +115,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass)
-			throws DataAccessException;
+	MultiDocumentEntity<? extends DocumentEntity> delete(Iterable<Object> values, Class<?> entityClass) throws DataAccessException;
 
 	/**
 	 * Removes a document
@@ -151,10 +160,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> update(
-		Iterable<T> values,
-		Class<T> entityClass,
-		DocumentUpdateOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass, DocumentUpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Partially updates documents, the documents to update are specified by the _key attributes in the objects on
@@ -171,8 +177,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass)
-			throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> update(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Partially updates the document identified by document id or key. The value must contain a document with the
@@ -219,10 +224,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> replace(
-		Iterable<T> values,
-		Class<T> entityClass,
-		DocumentReplaceOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass, DocumentReplaceOptions options) throws DataAccessException;
 
 	/**
 	 * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
@@ -239,8 +241,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass)
-			throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> replace(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Replaces the document with key with the one in the body, provided there is such a document and no precondition is
@@ -311,10 +312,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> insert(
-		Iterable<T> values,
-		Class<T> entityClass,
-		DocumentCreateOptions options) throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass, DocumentCreateOptions options) throws DataAccessException;
 
 	/**
 	 * Creates new documents from the given documents, unless there is already a document with the _key given. If no
@@ -329,8 +327,7 @@ public interface ArangoOperations {
 	 * @return information about the documents
 	 * @throws DataAccessException
 	 */
-	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass)
-			throws DataAccessException;
+	<T> MultiDocumentEntity<? extends DocumentEntity> insert(Iterable<T> values, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Creates a new document from the given document, unless there is already a document with the _key given. If no
@@ -353,6 +350,35 @@ public interface ArangoOperations {
 	 * @return information about the document
 	 */
 	<T> DocumentEntity insert(T value) throws DataAccessException;
+
+	/**
+	 * Creates a new document from the given document, unless there is already a document with the _key given. If no
+	 * _key is given, a new unique _key is generated automatically.
+	 * 
+	 * @param collectionName
+	 *            Name of the collection in which the new document should be inserted
+	 * @param value
+	 *            A representation of a single document
+	 * @param options
+	 *            Additional options, can be null 
+	 * @return information about the document
+	 * @throws DataAccessException
+	 */
+	DocumentEntity insert(String collectionName, Object value, DocumentCreateOptions options) throws DataAccessException;
+
+	/**
+	
+	 * Creates a new document from the given document, unless there is already a document with the _key given. If no
+	 * _key is given, a new unique _key is generated automatically.
+	 * 
+	 * @param collectionName
+	 *            Name of the collection in which the new document should be inserted 
+	 * @param value
+	 *            A representation of a single document 
+	 * @return information about the document
+	 * @throws DataAccessException
+	 */
+	DocumentEntity insert(String collectionName, Object value) throws DataAccessException;
 
 	public enum UpsertStrategy {
 		REPLACE, UPDATE

--- a/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
+++ b/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
@@ -95,6 +95,13 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	}
 
 	@Test
+	public void insertDocumentWithCollName() {
+		final DocumentEntity res = template.insert("customer", new Customer("John", "Doe", 30));
+		assertThat(res, is(notNullValue()));
+		assertThat(res.getId(), is(notNullValue()));
+	}
+
+	@Test
 	public void upsertReplace() {
 		final Customer customer = new Customer("John", "Doe", 30);
 		template.upsert(customer, UpsertStrategy.REPLACE);
@@ -279,6 +286,19 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 		template.insert(new Customer("John", "Doe", 30));
 		final ArangoCursor<Customer> cursor = template.query("FOR c IN @@coll FILTER c.name == @name RETURN c",
 			new MapBuilder().put("@coll", "customer").put("name", "John").get(), new AqlQueryOptions(), Customer.class);
+		assertThat(cursor, is(notNullValue()));
+		final List<Customer> customers = cursor.asListRemaining();
+		assertThat(customers.size(), is(1));
+		assertThat(customers.get(0).getName(), is("John"));
+		assertThat(customers.get(0).getSurname(), is("Doe"));
+		assertThat(customers.get(0).getAge(), is(30));
+	}
+
+	@Test
+	public void queryWithoutBindParams() {
+		template.insert(new Customer("John", "Doe", 30));
+		final ArangoCursor<Customer> cursor = template.query("FOR c IN customer FILTER c.name == 'John' RETURN c", null,
+			new AqlQueryOptions(), Customer.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<Customer> customers = cursor.asListRemaining();
 		assertThat(customers.size(), is(1));


### PR DESCRIPTION
I added 2 insert methods to ArangoTemplate where the collection name can be explicitly specified. This can be useful when there is no entity class defined for the object (eg. specified as map). Selecting the target collection this way is already supported by the update methods via the id, so I thought, the same  should work for insert as well.
I also changed the query method in ArangoTemplate to not throw NPE when bindVars parameter is null. The ArangoDatabase Java class allows this method to be called with bindVars == null. When someone changes from the direct Java driver usage to spring-data then these NPEs can be annoying. Also added a new method without bindVars for convenience.