### PR TITLE
Type mapper implemented & custom conversions extended

### DIFF
--- a/src/main/java/com/arangodb/springframework/config/ArangoEntityClassScanner.java
+++ b/src/main/java/com/arangodb/springframework/config/ArangoEntityClassScanner.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.data.annotation.TypeAlias;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -35,12 +36,16 @@ import com.arangodb.springframework.annotation.Edge;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class ArangoEntityClassScanner {
 
 	@SuppressWarnings("unchecked")
 	private static final Class<? extends Annotation>[] ENTITY_ANNOTATIONS = new Class[] { Document.class, Edge.class };
+	
+	@SuppressWarnings("unchecked")
+	private static final Class<? extends Annotation>[] ADDITIONAL_ANNOTATIONS = new Class[] { TypeAlias.class };
 
 	public static Set<Class<?>> scanForEntities(final String... basePackages) throws ClassNotFoundException {
 		final Set<Class<?>> entities = new HashSet<>();
@@ -56,6 +61,9 @@ public class ArangoEntityClassScanner {
 			final ClassPathScanningCandidateComponentProvider componentProvider = new ClassPathScanningCandidateComponentProvider(
 					false);
 			for (final Class<? extends Annotation> annotationType : ENTITY_ANNOTATIONS) {
+				componentProvider.addIncludeFilter(new AnnotationTypeFilter(annotationType));
+			}
+			for (final Class<? extends Annotation> annotationType : ADDITIONAL_ANNOTATIONS) {
 				componentProvider.addIncludeFilter(new AnnotationTypeFilter(annotationType));
 			}
 			for (final BeanDefinition definition : componentProvider.findCandidateComponents(basePackage)) {

--- a/src/main/java/com/arangodb/springframework/core/convert/ArangoCustomConversions.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/ArangoCustomConversions.java
@@ -23,6 +23,7 @@ package com.arangodb.springframework.core.convert;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -33,10 +34,12 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.JodaTimeConverters;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.mapping.model.SimpleTypeHolder;
+
+import com.arangodb.springframework.core.mapping.ArangoSimpleTypes;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class ArangoCustomConversions extends CustomConversions {
@@ -44,11 +47,13 @@ public class ArangoCustomConversions extends CustomConversions {
 	private static final StoreConversions STORE_CONVERSIONS;
 
 	static {
-		final Collection<Converter<?, ?>> converters = new ArrayList<>();
-		converters.addAll(JodaTimeConverters.getConvertersToRegister());
-		converters.addAll(TimeStringConverters.getConvertersToRegister());
-		converters.addAll(JodaTimeStringConverters.getConvertersToRegister());
-		STORE_CONVERSIONS = StoreConversions.of(SimpleTypeHolder.DEFAULT, converters);
+		final Collection<Converter<?, ?>> storeConverters = new ArrayList<>();
+		storeConverters.addAll(JodaTimeConverters.getConvertersToRegister());
+		storeConverters.addAll(TimeStringConverters.getConvertersToRegister());
+		storeConverters.addAll(JodaTimeStringConverters.getConvertersToRegister());
+		
+		STORE_CONVERSIONS = StoreConversions.of(ArangoSimpleTypes.HOLDER,
+			Collections.unmodifiableCollection(storeConverters));
 	}
 
 	public ArangoCustomConversions(final Collection<?> converters) {

--- a/src/main/java/com/arangodb/springframework/core/convert/ArangoTypeMapper.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/ArangoTypeMapper.java
@@ -1,7 +1,7 @@
 /*
  * DISCLAIMER
  *
- * Copyright 2017 ArangoDB GmbH, Cologne, Germany
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,14 @@
 
 package com.arangodb.springframework.core.convert;
 
-import org.springframework.core.convert.support.GenericConversionService;
-import org.springframework.data.mapping.context.MappingContext;
-
-import com.arangodb.springframework.core.mapping.ArangoPersistentEntity;
-import com.arangodb.springframework.core.mapping.ArangoPersistentProperty;
+import org.springframework.data.convert.TypeMapper;
 
 /**
- * @author Mark Vollmary
  * @author Christian Lechner
  *
  */
-public interface ArangoConverter extends ArangoEntityReader, ArangoEntityWriter {
+public interface ArangoTypeMapper extends TypeMapper<DBEntity> {
 
-	MappingContext<? extends ArangoPersistentEntity<?>, ArangoPersistentProperty> getMappingContext();
-
-	boolean isCollectionType(Class<?> type);
-
-	boolean isEntityType(Class<?> type);
-
-	GenericConversionService getConversionService();
-
-	ArangoTypeMapper getTypeMapper();
+	boolean isTypeKey(String key);
 
 }

--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
@@ -47,6 +47,7 @@ import org.springframework.data.mapping.model.PersistentEntityParameterValueProv
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 
 import com.arangodb.entity.BaseDocument;
@@ -58,6 +59,7 @@ import com.arangodb.velocypack.VPackSlice;
 
 /**
  * @author Mark Vollmary
+ * @author Christian Lechner
  *
  */
 public class DefaultArangoConverter implements ArangoConverter {
@@ -69,14 +71,16 @@ public class DefaultArangoConverter implements ArangoConverter {
 	private final GenericConversionService conversionService;
 	private final EntityInstantiators instantiators;
 	private final ResolverFactory resolverFactory;
+	private final ArangoTypeMapper typeMapper;
 
 	public DefaultArangoConverter(
 		final MappingContext<? extends ArangoPersistentEntity<?>, ArangoPersistentProperty> context,
-		final CustomConversions conversions, final ResolverFactory resolverFactory) {
+		final CustomConversions conversions, final ResolverFactory resolverFactory, final ArangoTypeMapper typeMapper) {
 		super();
 		this.context = context;
 		this.conversions = conversions;
 		this.resolverFactory = resolverFactory;
+		this.typeMapper = typeMapper;
 		conversionService = new DefaultConversionService();
 		conversions.registerConvertersIn(conversionService);
 		instantiators = new EntityInstantiators();
@@ -85,6 +89,11 @@ public class DefaultArangoConverter implements ArangoConverter {
 	@Override
 	public MappingContext<? extends ArangoPersistentEntity<?>, ArangoPersistentProperty> getMappingContext() {
 		return context;
+	}
+
+	@Override
+	public ArangoTypeMapper getTypeMapper() {
+		return typeMapper;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -97,26 +106,48 @@ public class DefaultArangoConverter implements ArangoConverter {
 		if (source == null) {
 			return null;
 		}
-		if (conversions.hasCustomReadTarget(type.getType(), type.getType())) {
-			return conversionService.convert(source, type.getType());
+
+		TypeInformation<?> typeToUse = typeMapper.readType(source, type);
+
+		if (conversions.hasCustomReadTarget(source.getClass(), typeToUse.getType())) {
+			return conversionService.convert(source, typeToUse.getType());
 		}
-		if (isMapType(type.getType()) && source instanceof DBDocumentEntity) {
-			return readMap(type, DBDocumentEntity.class.cast(source));
+
+		if (DBEntity.class.isAssignableFrom(typeToUse.getType())) {
+			return source;
 		}
-		if (type.isCollectionLike() && source instanceof DBCollectionEntity) {
-			return readCollection(type, DBCollectionEntity.class.cast(source));
+
+		if (typeToUse.isMap()) {
+			return readMap(typeToUse, DBDocumentEntity.class.cast(source));
 		}
+		if (typeToUse.isCollectionLike()) {
+			return readCollection(typeToUse, DBCollectionEntity.class.cast(source));
+		}
+
+		// no type information available => stick to the given type of the source
+		if (typeToUse.equals(ClassTypeInformation.OBJECT)) {
+			if (source instanceof DBDocumentEntity) {
+				return readMap(ClassTypeInformation.MAP, DBDocumentEntity.class.cast(source));
+			} else if (source instanceof DBCollectionEntity) {
+				return readCollection(ClassTypeInformation.LIST, DBCollectionEntity.class.cast(source));
+			}
+			return source;
+		}
+
 		final Optional<? extends ArangoPersistentEntity<?>> entity = Optional
-				.ofNullable(context.getPersistentEntity(type.getType()));
-		return read(type, source, entity);
+				.ofNullable(context.getPersistentEntity(typeToUse.getType()));
+		return read(typeToUse, source, entity);
 	}
 
 	@SuppressWarnings("unchecked")
 	private Object readMap(final TypeInformation<?> type, final DBDocumentEntity source) {
-		final Class<?> keyType = type.getComponentType().getType();
-		final TypeInformation<?> valueType = type.getMapValueType();
+		final Class<?> keyType = getNonNullComponentType(type).getType();
+		final TypeInformation<?> valueType = getNonNullMapValueType(type);
 		final Map<Object, Object> map = CollectionFactory.createMap(type.getType(), keyType, source.size());
 		for (final Map.Entry<String, Object> entry : source.entrySet()) {
+			if (typeMapper.isTypeKey(entry.getKey())) {
+				continue;
+			}
 			final Object key = conversionService.convert(entry.getKey(), keyType);
 			final Object value = entry.getValue();
 			if (value instanceof DBEntity) {
@@ -139,7 +170,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 	@SuppressWarnings("unchecked")
 	private Object readCollection(final TypeInformation<?> type, final DBCollectionEntity source) {
 		final Class<?> collectionType = Collection.class.isAssignableFrom(type.getType()) ? type.getType() : List.class;
-		final TypeInformation<?> componentType = getComponentType(type);
+		final TypeInformation<?> componentType = getNonNullComponentType(type);
 		final Collection<Object> entries = type.getType().isArray() ? new ArrayList<>()
 				: CollectionFactory.createCollection(collectionType, componentType.getType(), source.size());
 		for (final Object entry : source) {
@@ -173,11 +204,15 @@ public class DefaultArangoConverter implements ArangoConverter {
 				conversionService);
 
 		entity.doWithProperties((final ArangoPersistentProperty property) -> {
-			readProperty(source.get(_ID), accessor, source.get(property.getFieldName()), property);
+			if (!entity.isConstructorArgument(property)) {
+				readProperty(source.get(_ID), accessor, source.get(property.getFieldName()), property);
+			}
 		});
 		entity.doWithAssociations((final Association<ArangoPersistentProperty> association) -> {
 			final ArangoPersistentProperty property = association.getInverse();
-			readProperty(source.get(_ID), accessor, source.get(property.getFieldName()), property);
+			if (!entity.isConstructorArgument(property)) {
+				readProperty(source.get(_ID), accessor, source.get(property.getFieldName()), property);
+			}
 		});
 		return instance;
 	}
@@ -215,7 +250,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 		final ArangoPersistentProperty property) {
 		final Optional<Object> referenceOrRelation = readReferenceOrRelation(parentId, source, property);
 		accessor.setProperty(property,
-			referenceOrRelation.orElseGet(() -> (read(source, property.getTypeInformation()))));
+			referenceOrRelation.orElseGet(() -> read(source, property.getTypeInformation())));
 	}
 
 	private Optional<Object> readReferenceOrRelation(
@@ -309,20 +344,39 @@ public class DefaultArangoConverter implements ArangoConverter {
 		if (source == null) {
 			return;
 		}
-		write(source, ClassTypeInformation.from(source.getClass()), sink);
+
+		if (sink instanceof DBDocumentEntity) {
+			final boolean hasCustomTarget = conversions.hasCustomWriteTarget(source.getClass(), DBDocumentEntity.class);
+			if (hasCustomTarget) {
+				final DBDocumentEntity result = conversionService.convert(source, DBDocumentEntity.class);
+				((DBDocumentEntity) sink).putAll(result);
+				return;
+			}
+		}
+
+		final TypeInformation<?> type = ClassTypeInformation.from(ClassUtils.getUserClass(source.getClass()));
+		final TypeInformation<?> definedType = ClassTypeInformation.OBJECT;
+
+		write(source, type, sink, definedType);
 	}
 
 	@SuppressWarnings("unchecked")
-	private void write(final Object source, final TypeInformation<?> type, final DBEntity sink) {
-		if (isMapType(type.getType())) {
-			writeMap((Map<Object, Object>) source, sink);
+	private void write(
+		final Object source,
+		final TypeInformation<?> type,
+		final DBEntity sink,
+		final TypeInformation<?> definedType) {
+
+		if (type.isMap()) {
+			writeMap((Map<Object, Object>) source, sink, definedType);
 			return;
 		}
-		if (isCollectionType(type.getType())) {
-			writeCollection(source, sink);
+		if (type.isCollectionLike()) {
+			writeCollection(source, sink, definedType);
 			return;
 		}
 		write(source, sink, Optional.ofNullable(context.getPersistentEntity(type)));
+		addTypeKeyIfNecessary(definedType, source, sink);
 	}
 
 	private void write(
@@ -367,11 +421,11 @@ public class DefaultArangoConverter implements ArangoConverter {
 			if (valueType.isCollectionLike()) {
 				final Collection<Object> ids = new ArrayList<>();
 				for (final Object ref : createCollection(asCollection(source), property)) {
-					getId(ref, property).ifPresent(id -> ids.add(id));
+					getId(ref).ifPresent(id -> ids.add(id));
 				}
 				sink.put(fieldName, ids);
 			} else {
-				getId(source, property).ifPresent(id -> sink.put(fieldName, id));
+				getId(source).ifPresent(id -> sink.put(fieldName, id));
 			}
 			return;
 		}
@@ -380,29 +434,30 @@ public class DefaultArangoConverter implements ArangoConverter {
 		}
 		if (property.getFrom().isPresent() || property.getTo().isPresent()) {
 			if (!valueType.isCollectionLike()) {
-				getId(source, property).ifPresent(id -> sink.put(fieldName, id));
+				getId(source).ifPresent(id -> sink.put(fieldName, id));
 			}
 			return;
 		}
 		if (valueType.isCollectionLike()) {
 			final DBEntity collection = new DBCollectionEntity();
-			writeCollection(source, collection);
+			writeCollection(source, collection, property.getTypeInformation());
 			sink.put(fieldName, collection);
 			return;
 		}
 		if (valueType.isMap()) {
 			final DBEntity map = new DBDocumentEntity();
-			writeMap((Map<Object, Object>) source, map);
+			writeMap((Map<Object, Object>) source, map, property.getTypeInformation());
 			sink.put(fieldName, map);
 			return;
 		}
 		final Optional<Class<?>> customWriteTarget = conversions.getCustomWriteTarget(source.getClass());
-		final Class<?> targetType = customWriteTarget.orElseGet(() -> property.getTypeInformation().getType());
+		final Class<?> targetType = customWriteTarget.orElseGet(() -> valueType.getType());
 		final DBEntity document = new DBDocumentEntity();
 		final Optional<? extends ArangoPersistentEntity<?>> persistentEntity = Optional
 				.ofNullable(context.getPersistentEntity(targetType));
 		if (persistentEntity.isPresent()) {
 			write(source, document, persistentEntity);
+			addTypeKeyIfNecessary(property.getTypeInformation(), source, document);
 			sink.put(fieldName, document);
 		} else {
 			sink.put(fieldName, conversionService.convert(source, targetType));
@@ -410,28 +465,27 @@ public class DefaultArangoConverter implements ArangoConverter {
 		return;
 	}
 
-	private void writeMap(final Map<Object, Object> source, final DBEntity sink) {
+	private void writeMap(final Map<Object, Object> source, final DBEntity sink, final TypeInformation<?> definedType) {
 		for (final Entry<Object, Object> entry : source.entrySet()) {
 			final Object key = entry.getKey();
 			if (!conversions.isSimpleType(key.getClass())) {
-				throw new MappingException(
-						"Complexe type as Map key value is not allowed! fount type " + key.getClass());
+				throw new MappingException("Complex type " + key.getClass().getName() + " is not allowed as a map key!");
 			}
 			final Object value = entry.getValue();
 			final Class<? extends Object> valueType = value.getClass();
 			if (conversions.isSimpleType(valueType)) {
 				final Optional<Class<?>> customWriteTarget = conversions.getCustomWriteTarget(valueType);
 				final Class<?> targetType = customWriteTarget.orElseGet(() -> valueType);
-				sink.put(key.toString(), conversionService.convert(value, targetType));
+				sink.put(convertMapKey(key), conversionService.convert(value, targetType));
 			} else {
 				final DBEntity entity = createDBEntity(valueType);
-				write(value, ClassTypeInformation.from(valueType), entity);
-				sink.put(key.toString(), entity);
+				write(value, ClassTypeInformation.from(valueType), entity, getNonNullMapValueType(definedType));
+				sink.put(convertMapKey(key), entity);
 			}
 		}
 	}
 
-	private void writeCollection(final Object source, final DBEntity sink) {
+	private void writeCollection(final Object source, final DBEntity sink, final TypeInformation<?> definedType) {
 		for (final Object entry : asCollection(source)) {
 			final Class<? extends Object> valueType = entry.getClass();
 			if (conversions.isSimpleType(valueType)) {
@@ -440,18 +494,18 @@ public class DefaultArangoConverter implements ArangoConverter {
 				sink.add(conversionService.convert(entry, targetType));
 			} else {
 				final DBEntity entity = createDBEntity(valueType);
-				write(entry, ClassTypeInformation.from(valueType), entity);
+				write(entry, ClassTypeInformation.from(valueType), entity, getNonNullComponentType(definedType));
 				sink.add(entity);
 			}
 		}
 	}
 
-	private Optional<Object> getId(final Object source, final ArangoPersistentProperty property) {
-		return Optional.ofNullable(context.getPersistentEntity(property)).flatMap(entity -> getId(source, entity));
+	private Optional<Object> getId(final Object source) {
+		return getId(source, context.getPersistentEntity(source.getClass()));
 	}
 
 	private Optional<Object> getId(final Object source, final ArangoPersistentEntity<?> entity) {
-		return Optional.ofNullable(entity.getIdProperty()).map(p -> entity.getPropertyAccessor(source).getProperty(p));
+		return Optional.ofNullable(entity.getIdentifierAccessor(source).getIdentifier());
 	}
 
 	private Collection<?> createCollection(final Collection<?> source, final ArangoPersistentProperty property) {
@@ -508,6 +562,32 @@ public class DefaultArangoConverter implements ArangoConverter {
 	private String determineDocumentKeyFromId(final String id) {
 		final String[] split = id.split("/");
 		return split[split.length - 1];
+	}
+
+	private void addTypeKeyIfNecessary(final TypeInformation<?> definedType, final Object value, final DBEntity sink) {
+		final Class<?> referenceType = definedType != null ? definedType.getType() : Object.class;
+		final Class<?> valueType = ClassUtils.getUserClass(value.getClass());
+		if (!valueType.equals(referenceType)) {
+			typeMapper.writeType(valueType, sink);
+		}
+	}
+
+	private String convertMapKey(final Object key) {
+		if (key instanceof String) {
+			return (String) key;
+		}
+		final boolean hasCustomConverter = conversions.hasCustomWriteTarget(key.getClass(), String.class);
+		return hasCustomConverter ? conversionService.convert(key, String.class) : key.toString();
+	}
+
+	private TypeInformation<?> getNonNullComponentType(final TypeInformation<?> type) {
+		final TypeInformation<?> compType = type.getComponentType();
+		return compType != null ? compType : ClassTypeInformation.OBJECT;
+	}
+
+	private TypeInformation<?> getNonNullMapValueType(final TypeInformation<?> type) {
+		final TypeInformation<?> valueType = type.getMapValueType();
+		return valueType != null ? valueType : ClassTypeInformation.OBJECT;
 	}
 
 }

--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoTypeMapper.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoTypeMapper.java
@@ -1,0 +1,104 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.convert;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.data.convert.DefaultTypeMapper;
+import org.springframework.data.convert.SimpleTypeInformationMapper;
+import org.springframework.data.convert.TypeAliasAccessor;
+import org.springframework.data.convert.TypeInformationMapper;
+import org.springframework.data.mapping.Alias;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.context.MappingContext;
+
+/**
+ * @author Christian Lechner
+ *
+ */
+public class DefaultArangoTypeMapper extends DefaultTypeMapper<DBEntity> implements ArangoTypeMapper {
+
+	public static final String DEFAULT_TYPE_KEY = "_type";
+	
+	private final String typeKey;
+
+	public DefaultArangoTypeMapper() {
+		this(DEFAULT_TYPE_KEY);
+	}
+
+	public DefaultArangoTypeMapper(String typeKey) {
+		this(typeKey, Arrays.asList(new SimpleTypeInformationMapper()));
+	}
+
+	public DefaultArangoTypeMapper(String typeKey, MappingContext<? extends PersistentEntity<?, ?>, ?> mappingContext) {
+		this(typeKey, new DocumentTypeAliasAccessor(typeKey), mappingContext,
+				Arrays.asList(new SimpleTypeInformationMapper()));
+	}
+
+	public DefaultArangoTypeMapper(String typeKey, List<? extends TypeInformationMapper> mappers) {
+		this(typeKey, new DocumentTypeAliasAccessor(typeKey), null, mappers);
+	}
+
+	private DefaultArangoTypeMapper(String typeKey, TypeAliasAccessor<DBEntity> accessor,
+		MappingContext<? extends PersistentEntity<?, ?>, ?> mappingContext,
+		List<? extends TypeInformationMapper> mappers) {
+
+		super(accessor, mappingContext, mappers);
+		this.typeKey = typeKey;
+	}
+	
+	@Override
+	public boolean isTypeKey(final String key) {
+		return typeKey == null ? false : typeKey.equals(key);
+	}
+
+	public static final class DocumentTypeAliasAccessor implements TypeAliasAccessor<DBEntity> {
+
+		private final String typeKey;
+
+		public DocumentTypeAliasAccessor(String typeKey) {
+			this.typeKey = typeKey;
+		}
+
+		@Override
+		public Alias readAliasFrom(DBEntity source) {
+			if (source instanceof DBCollectionEntity) {
+				return Alias.NONE;
+			}
+
+			if (source instanceof DBDocumentEntity) {
+				return Alias.ofNullable(source.get(this.typeKey));
+			}
+
+			throw new IllegalArgumentException("Cannot read alias from " + source.getClass());
+		}
+
+		@Override
+		public void writeTypeTo(DBEntity sink, Object alias) {
+			if (this.typeKey != null && sink instanceof DBDocumentEntity) {
+				sink.put(this.typeKey, alias);
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/com/arangodb/springframework/core/mapping/ArangoSimpleTypes.java
+++ b/src/main/java/com/arangodb/springframework/core/mapping/ArangoSimpleTypes.java
@@ -1,0 +1,51 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.mapping;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+
+import com.arangodb.springframework.core.convert.DBEntity;
+
+/**
+ * @author Christian Lechner
+ *
+ */
+public abstract class ArangoSimpleTypes {
+
+	private static final Set<Class<?>> ARANGO_SIMPLE_TYPES;
+
+	static {
+		Set<Class<?>> simpleTypes = new HashSet<Class<?>>();
+		simpleTypes.add(DBEntity.class);
+
+		ARANGO_SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
+	}
+
+	public static final SimpleTypeHolder HOLDER = new SimpleTypeHolder(ARANGO_SIMPLE_TYPES, true);
+
+	private ArangoSimpleTypes() {
+	}
+
+}


### PR DESCRIPTION
**Change log:**
- Type mapper implemented:
  - type hints are added to objects if:
    - the defined type is a super type of the given one _or_
    - no type is defined (`Object` or root objects) _or_
    - defined type can not be determined (generics, e.g. `List<T>`) _or_
    - object is not an instance of `List` or `Map`
  - the type mapper can be configured by extending `AbstractArangoConfiguration`
  - As default type hint the fully qualified class name is used, but can be customized by adding `@TypeAlias("my-alias")` annotation to a class
  - `ArangoEntityClassScanner` scans also for classes with `TypeAlias` annotations (don't forget to override `getEntityBasePackages()` of `AbstractArangoConfiguration` and return all base packages with entity classes. Otherwise type aliases can't be resolved to class names if the class has not been added to the mapping context before (e.g. through saving a class with an alias). 
  - also works for references

- Custom conversions extended:
  - works now with `DBEntity` objects
  - complex map keys are serialized to string (if there is a registered converter, otherwise `toString()` is used)
  - root objects can now also be serialized using converters
- other small changes

I would like to discuss my changes and implementation of the type mapper and the extended conversions. I appreciate every feedback.