### PR TITLE
Fix race conditions in ArangoTemplate when creating database and collections

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -108,7 +108,8 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback {
 		this.databaseName = database;
 		this.converter = converter;
 		this.exceptionTranslator = exceptionTranslator;
-		collectionCache = new ConcurrentHashMap<>(16, 0.75f, 4);
+		// set concurrency level to 1 as writes are very rare compared to reads
+		collectionCache = new ConcurrentHashMap<>(8, 0.9f, 1);
 		version = null;
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -87,7 +87,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback {
 	private final PersistenceExceptionTranslator exceptionTranslator;
 	private final ArangoConverter converter;
 	private final ArangoDB arango;
-	private ArangoDatabase database;
+	private volatile ArangoDatabase database;
 	private final String databaseName;
 	private final Map<String, ArangoCollection> collectionCache;
 

--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -135,8 +135,8 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback {
 				}
 			}
 			this.database = db;
-			return db;
 		}
+		return this.database;
 	}
 
 	private DataAccessException translateExceptionIfPossible(final RuntimeException exception) {


### PR DESCRIPTION
As Spring Beans are singletons by default and we have a multi-threaded environment, we must be careful with operations that change the state of the class.