### PR TITLE
ArangoCursor support in repos (for Spring Data Commons 2.0.7) & projection support

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
@@ -25,14 +25,21 @@ import java.util.Optional;
 
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.AnnotationRepositoryMetadata;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.util.Assert;
 
+import com.arangodb.ArangoCursor;
 import com.arangodb.springframework.core.ArangoOperations;
 import com.arangodb.springframework.core.mapping.ArangoPersistentEntity;
 import com.arangodb.springframework.core.mapping.ArangoPersistentProperty;
@@ -73,6 +80,15 @@ public class ArangoRepositoryFactory extends RepositoryFactorySupport {
 	@Override
 	protected Class<?> getRepositoryBaseClass(final RepositoryMetadata metadata) {
 		return SimpleArangoRepository.class;
+	}
+
+	@Override
+	protected RepositoryMetadata getRepositoryMetadata(Class<?> repositoryInterface) {
+		Assert.notNull(repositoryInterface, "Repository interface must not be null!");
+
+		return Repository.class.isAssignableFrom(repositoryInterface)
+				? new DefaultArangoRepositoryMetadata(repositoryInterface)
+				: new AnnotationArangoRepositoryMetadata(repositoryInterface);
 	}
 
 	@Override
@@ -118,6 +134,46 @@ public class ArangoRepositoryFactory extends RepositoryFactorySupport {
 				return new StringBasedArangoQuery(queryMethod, operations);
 			} else {
 				return new DerivedArangoQuery(queryMethod, operations);
+			}
+		}
+
+	}
+
+	static class DefaultArangoRepositoryMetadata extends DefaultRepositoryMetadata {
+
+		private final TypeInformation<?> typeInformation;
+
+		public DefaultArangoRepositoryMetadata(Class<?> repositoryInterface) {
+			super(repositoryInterface);
+			typeInformation = ClassTypeInformation.from(repositoryInterface);
+		}
+
+		@Override
+		public Class<?> getReturnedDomainClass(Method method) {
+			if (ArangoCursor.class.isAssignableFrom(method.getReturnType())) {
+				return typeInformation.getReturnType(method).getRequiredComponentType().getType();
+			} else {
+				return super.getReturnedDomainClass(method);
+			}
+		}
+
+	}
+
+	static class AnnotationArangoRepositoryMetadata extends AnnotationRepositoryMetadata {
+
+		private final TypeInformation<?> typeInformation;
+
+		public AnnotationArangoRepositoryMetadata(Class<?> repositoryInterface) {
+			super(repositoryInterface);
+			typeInformation = ClassTypeInformation.from(repositoryInterface);
+		}
+
+		@Override
+		public Class<?> getReturnedDomainClass(Method method) {
+			if (ArangoCursor.class.isAssignableFrom(method.getReturnType())) {
+				return typeInformation.getReturnType(method).getRequiredComponentType().getType();
+			} else {
+				return super.getReturnedDomainClass(method);
 			}
 		}
 

--- a/src/main/java/com/arangodb/springframework/repository/query/AbstractArangoQuery.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/AbstractArangoQuery.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.springframework.data.geo.GeoPage;
 import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.util.Assert;
 
 import com.arangodb.ArangoCursor;
@@ -68,8 +69,12 @@ public abstract class AbstractArangoQuery implements RepositoryQuery {
 		}
 
 		final String query = createQuery(accessor, bindVars, options);
-		final ArangoCursor<?> result = operations.query(query, bindVars, options, getResultClass());
-		return convertResult(result, accessor);
+		
+		final ResultProcessor processor = method.getResultProcessor().withDynamicProjection(accessor);
+		final Class<?> typeToRead = getTypeToRead(processor);
+		
+		final ArangoCursor<?> result = operations.query(query, bindVars, options, typeToRead);
+		return processor.processResult(convertResult(result, accessor));
 	}
 
 	@Override
@@ -148,14 +153,17 @@ public abstract class AbstractArangoQuery implements RepositoryQuery {
 		return oldStatic;
 	}
 
-	private Class<?> getResultClass() {
+	private Class<?> getTypeToRead(final ResultProcessor processor) {
 		if (isExistsQuery()) {
 			return Integer.class;
 		}
+		
 		if (method.isGeoQuery()) {
-			return Object.class;
+			return Map.class;
 		}
-		return method.getReturnedObjectType();
+		
+		final Class<?> typeToRead = processor.getReturnedType().getTypeToRead();
+		return typeToRead != null ? typeToRead : Map.class;
 	}
 
 	private Object convertResult(final ArangoCursor<?> result, final ArangoParameterAccessor accessor) {
@@ -163,7 +171,7 @@ public abstract class AbstractArangoQuery implements RepositoryQuery {
 			if (!result.hasNext()) {
 				return false;
 			}
-			return Integer.valueOf(result.next().toString()) > 0;
+			return (int) result.next() > 0;
 		}
 		final ArangoResultConverter resultConverter = new ArangoResultConverter(accessor, result, operations,
 				domainClass);

--- a/src/main/java/com/arangodb/springframework/repository/query/AbstractArangoQuery.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/AbstractArangoQuery.java
@@ -155,9 +155,6 @@ public abstract class AbstractArangoQuery implements RepositoryQuery {
 		if (method.isGeoQuery()) {
 			return Object.class;
 		}
-		if (ArangoCursor.class.isAssignableFrom(method.getReturnType().getType())) {
-			return method.getReturnType().getRequiredComponentType().getType();
-		}
 		return method.getReturnedObjectType();
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -28,6 +28,7 @@ import com.arangodb.springframework.annotation.Query;
 import com.arangodb.springframework.annotation.QueryOptions;
 import com.arangodb.springframework.repository.query.derived.geo.Ring;
 import com.arangodb.springframework.testdata.Customer;
+import com.arangodb.springframework.testdata.CustomerNameProjection;
 
 /**
  * 
@@ -188,10 +189,10 @@ public interface CustomerRepository extends ArangoRepository<Customer> {
 	List<Customer> getByOwnsContainsName(String name);
 
 	// Count query
-	
+
 	@Query("RETURN COUNT(@@collection)")
 	long queryCount(@Param("@collection") Class<Customer> collection);
-	
+
 	// Date query
 
 	@Query("RETURN DATE_ISO8601(1474988621)")
@@ -200,4 +201,21 @@ public interface CustomerRepository extends ArangoRepository<Customer> {
 	// Named query
 
 	Customer findOneByIdNamedQuery(@Param("id") String id);
+
+	// Static projection
+
+	@Query("FOR c IN customer FILTER c._id == @id RETURN c")
+	CustomerNameProjection findOneByIdWithStaticProjection(@Param("id") String id);
+
+	@Query("FOR c IN customer FILTER c.age >= 18 RETURN c")
+	List<CustomerNameProjection> findManyLegalAgeWithStaticProjection();
+
+	// Dynamic projection
+
+	@Query("FOR c IN customer FILTER c._id == @id RETURN c")
+	<T> T findOneByIdWithDynamicProjection(@Param("id") String id, Class<T> projection);
+
+	@Query("FOR c IN customer FILTER c.age >= 18 RETURN c")
+	<T> List<T> findManyLegalAgeWithDynamicProjection(Class<T> projection);
+
 }

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -1,5 +1,7 @@
 package com.arangodb.springframework.repository.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIn.isOneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -20,6 +22,7 @@ import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.core.convert.DBDocumentEntity;
 import com.arangodb.springframework.repository.AbstractArangoRepositoryTest;
 import com.arangodb.springframework.testdata.Customer;
+import com.arangodb.springframework.testdata.CustomerNameProjection;
 
 /**
  * 
@@ -154,4 +157,39 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		final Customer retrieved = repository.findOneByIdNamedQuery(john.getId());
 		assertEquals(john, retrieved);
 	}
+
+	@Test
+	public void findOneByIdWithStaticProjectionTest() {
+		repository.saveAll(customers);
+		final CustomerNameProjection retrieved = repository.findOneByIdWithStaticProjection(john.getId());
+		assertEquals(retrieved.getName(), john.getName());
+	}
+
+	@Test
+	public void findManyLegalAgeWithStaticProjectionTest() {
+		repository.saveAll(customers);
+		final List<CustomerNameProjection> retrieved = repository.findManyLegalAgeWithStaticProjection();
+		for (CustomerNameProjection proj : retrieved) {
+			assertThat(proj.getName(), isOneOf(john.getName(), bob.getName()));
+		}
+	}
+
+	@Test
+	public void findOneByIdWithDynamicProjectionTest() {
+		repository.saveAll(customers);
+		final CustomerNameProjection retrieved = repository.findOneByIdWithDynamicProjection(john.getId(),
+			CustomerNameProjection.class);
+		assertEquals(retrieved.getName(), john.getName());
+	}
+
+	@Test
+	public void findManyLegalAgeWithDynamicProjectionTest() {
+		repository.saveAll(customers);
+		final List<CustomerNameProjection> retrieved = repository
+				.findManyLegalAgeWithDynamicProjection(CustomerNameProjection.class);
+		for (CustomerNameProjection proj : retrieved) {
+			assertThat(proj.getName(), isOneOf(john.getName(), bob.getName()));
+		}
+	}
+
 }

--- a/src/test/java/com/arangodb/springframework/testdata/CustomerNameProjection.java
+++ b/src/test/java/com/arangodb/springframework/testdata/CustomerNameProjection.java
@@ -1,0 +1,7 @@
+package com.arangodb.springframework.testdata;
+
+public interface CustomerNameProjection {
+	
+	String getName();
+
+}


### PR DESCRIPTION
**Changelog:**
- continue supporting `ArangoCursor` in repositories through custom `RepositoryMetadata` (necessary for Spring Data Commons 2.0.7)
- projection support through `ResultProcessor`