### PR TITLE
Support for Pageable and Sort in native queries

### DIFF
--- a/docs/Drivers/SpringData/Reference/README.md
+++ b/docs/Drivers/SpringData/Reference/README.md
@@ -272,7 +272,7 @@ ArangoCursor<Customer> cursor = myRepo.query(bindVars);
 
 You can set additional options for the query and the created cursor over the class `AqlQueryOptions` which you can simply define as a method parameter without a specific name. AqlQuery options can also be defined with the `@QueryOptions` annotation, as shown below. AqlQueryOptions from an annotation and those from an argument are merged if both exist, with those in the argument taking precedence.
 
-The `AqlQueryOptions` allows you to set the cursor time-to-life, batch-size, caching flag and several other settings. This special parameter works with both query-methods and finder-methods. Keep in mind that some options, like time-to-life, are only effective if the method return type is`ArangoCursor<T>` or `Iterable<T>`.
+The `AqlQueryOptions` allows you to set the cursor time-to-live, batch-size, caching flag and several other settings. This special parameter works with both query-methods and finder-methods. Keep in mind that some options, like time-to-live, are only effective if the method return type is`ArangoCursor<T>` or `Iterable<T>`.
 
 ```java
 public interface MyRepository extends Repository<Customer, String> {
@@ -294,6 +294,59 @@ public interface MyRepository extends Repository<Customer, String> {
   ArangoCursor<Customer> query(Map<String, Object> bindVars, AqlQueryOptions options);
 
 }
+```
+
+### Paging and sorting
+
+Spring Data ArangoDB supports Spring Data's `Pageable` and `Sort` parameters for repository query methods. If these parameters are used together with a native query, either through `@Query` annotation or named queries, a placeholder must be specified:
+- `#pageable` for `Pageable` parameter
+- `#sort` for `Sort` parameter
+
+Sort properties or paths are attributes separated by dots (e.g. `customer.age`). Some rules apply for them:
+- they must not begin or end with a dot (e.g. `.customer.age`)
+- dots in attributes are supported, but the whole attribute must be enclosed by backticks (e.g. ``customer.`attr.with.dots` ``
+- backticks in attributes are supported, but they must be escaped with a backslash (e.g. ``customer.attr_with\` ``)
+- any backslashes (that do not escape a backtick) are escaped (e.g. `customer\` => `customer\\`)
+
+```
+just.`some`.`attributes.that`.`form\``.a path\`.\  is converted to
+`just`.`some`.`attributes.that`.`form\``.`a path\``.`\\`
+```
+
+Native queries example:
+```java
+public interface CustomerRepository extends ArangoRepository<Customer> {
+
+  @Query("FOR c IN customer FILTER c.name == @1 #pageable RETURN c")
+  Page<Customer> findByNameNative(Pageable pageable, String name);
+	
+  @Query("FOR c IN customer FILTER c.name == @1 #sort RETURN c")
+  List<Customer> findByNameNative(Sort sort, String name);
+}
+
+// don't forget to specify the var name of the document
+final Pageable page = PageRequest.of(1, 10, Sort.by("c.age"));
+repository.findByNameNative(page, "Matt");
+
+final Sort sort = Sort.by(Direction.DESC, "c.age");
+repository.findByNameNative(sort, "Tony");
+```
+
+Derived queries example:
+```java
+public interface CustomerRepository extends ArangoRepository<Customer> {
+
+  Page<Customer> findByName(Pageable pageable, String name);
+	
+  List<Customer> findByName(Sort sort, String name);
+}
+
+// no var name is necessary for derived queries
+final Pageable page = PageRequest.of(1, 10, Sort.by("age"));
+repository.findByName(page, "Matt");
+
+final Sort sort = Sort.by(Direction.DESC, "age");
+repository.findByName(sort, "Tony");
 ```
 
 # Mapping

--- a/src/main/java/com/arangodb/springframework/core/util/AqlUtils.java
+++ b/src/main/java/com/arangodb/springframework/core/util/AqlUtils.java
@@ -1,0 +1,200 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.util;
+
+import java.util.StringJoiner;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * 
+ * @author Christian Lechner
+ */
+public final class AqlUtils {
+
+	private AqlUtils() {
+
+	}
+
+	public static String buildLimitClause(final Pageable pageable) {
+		if (pageable.isUnpaged()) {
+			return "";
+		}
+
+		final StringJoiner clause = new StringJoiner(", ", "LIMIT ", "");
+		clause.add(String.valueOf(pageable.getOffset()));
+		clause.add(String.valueOf(pageable.getPageSize()));
+		return clause.toString();
+	}
+
+	public static String buildPageableClause(final Pageable pageable) {
+		return buildPageableClause(pageable, null);
+	}
+
+	public static String buildPageableClause(final Pageable pageable, @Nullable final String varName) {
+		return buildPageableClause(pageable, varName, new StringBuilder()).toString();
+	}
+
+	private static StringBuilder buildPageableClause(
+		final Pageable pageable,
+		@Nullable final String varName,
+		final StringBuilder clause) {
+
+		if (pageable.isUnpaged()) {
+			return clause;
+		}
+		
+		Sort sort = pageable.getSort();
+		buildSortClause(sort, varName, clause);
+
+		if (sort.isSorted()) {
+			clause.append(' ');
+		}
+
+		clause.append("LIMIT ").append(pageable.getOffset()).append(", ").append(pageable.getPageSize());
+		return clause;
+	}
+
+	public static String buildSortClause(final Sort sort) {
+		return buildSortClause(sort, null);
+	}
+
+	public static String buildSortClause(final Sort sort, @Nullable final String varName) {
+		return buildSortClause(sort, varName, new StringBuilder()).toString();
+	}
+
+	private static StringBuilder buildSortClause(
+		final Sort sort,
+		@Nullable final String varName,
+		final StringBuilder clause) {
+		
+		if (sort.isUnsorted()) {
+			return clause;
+		}
+
+		final String prefix = StringUtils.hasText(varName) ? escapeSortProperty(varName) : null;
+		clause.append("SORT ");
+		boolean first = true;
+
+		for (final Sort.Order order : sort) {
+			if (!first) {
+				clause.append(", ");
+			} else {
+				first = false;
+			}
+
+			if (prefix != null) {
+				clause.append(prefix).append('.');
+			}
+			final String escapedProperty = escapeSortProperty(order.getProperty());
+			clause.append(escapedProperty).append(' ').append(order.getDirection());
+		}
+		return clause;
+
+	}
+
+	private static String escapeSortProperty(final String str) {
+		// dots are not allowed at start/end
+		if (str.charAt(0) == '.' || str.charAt(str.length() - 1) == '.') {
+			throw new IllegalArgumentException("Sort properties must not begin or end with a dot!");
+		}
+
+		final StringBuilder escaped = new StringBuilder();
+		escaped.append('`');
+
+		// keep track if we are inside an escaped sequence
+		boolean inEscapedSeq = false;
+
+		for (int i = 0; i < str.length(); ++i) {
+			final char currChar = str.charAt(i);
+			final boolean hasNext = (i + 1) < str.length();
+			final char nextChar = hasNext ? str.charAt(i + 1) : '\0';
+
+			if (currChar == '\\') {
+				// keep escaped backticks
+				if (nextChar == '`') {
+					escaped.append("\\`");
+					++i;
+				}
+				// escape backslashes
+				else {
+					escaped.append("\\\\");
+				}
+			}
+
+			// current char is an unescaped backtick
+			else if (currChar == '`') {
+				inEscapedSeq = !inEscapedSeq;
+
+				final boolean isStartOrEnd = i == 0 || !hasNext;
+				final boolean isNextCharDotOutsideEscapedSeq = nextChar == '.' && !inEscapedSeq;
+
+				// unescaped backticks are only allowed at start/end of attributes
+				if (!isStartOrEnd && !isNextCharDotOutsideEscapedSeq) {
+					throw new IllegalArgumentException(
+							"Sort properties must only contain backticks at beginning/end of attributes or when escaped.");
+				}
+			}
+
+			else if (currChar == '.') {
+				// the dot is part of an attribute name when inside escaped sequence
+				if (inEscapedSeq) {
+					// add dot without escaping
+					escaped.append('.');
+				}
+
+				else {
+					// properties can only contain 2+ dots in escaped sequences
+					if (nextChar == '.') {
+						throw new IllegalArgumentException(
+								"Sort properties may not contain 2+ consecutive dots when outside a backtick escape sequence!");
+					}
+					// consume optional backtick
+					else if (nextChar == '`') {
+						inEscapedSeq = !inEscapedSeq;
+						++i;
+					}
+
+					// close previous escape sequence and open new one
+					escaped.append("`.`");
+				}
+			}
+
+			// keep others
+			else {
+				escaped.append(currChar);
+			}
+		}
+
+		// check for an open escape sequence
+		if (inEscapedSeq) {
+			throw new IllegalArgumentException(
+					"A sort property contains an unclosed backtick escape sequence! The cause may be a missing backtick.");
+		}
+
+		escaped.append('`');
+		return escaped.toString();
+	}
+
+}

--- a/src/main/java/com/arangodb/springframework/repository/query/StringBasedArangoQuery.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/StringBasedArangoQuery.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.core.ArangoOperations;
+import com.arangodb.springframework.core.util.AqlUtils;
 import com.arangodb.springframework.repository.query.ArangoParameters.ArangoParameter;
 
 /**
@@ -41,7 +42,15 @@ import com.arangodb.springframework.repository.query.ArangoParameters.ArangoPara
  */
 public class StringBasedArangoQuery extends AbstractArangoQuery {
 
+	private static final String PAGEABLE_PLACEHOLDER = "#pageable";
+
+	private static final String SORT_PLACEHOLDER = "#sort";
+
 	private static final Pattern BIND_PARAM_PATTERN = Pattern.compile("@(@?[A-Za-z0-9][A-Za-z0-9_]*)");
+
+	private static final Pattern PAGEABLE_PLACEHOLDER_PATTERN = Pattern.compile(Pattern.quote(PAGEABLE_PLACEHOLDER));
+
+	private static final Pattern SORT_PLACEHOLDER_PATTERN = Pattern.compile(Pattern.quote(SORT_PLACEHOLDER));
 
 	private final String query;
 	private final Set<String> queryBindParams;
@@ -55,6 +64,10 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 		Assert.notNull(query, "Query must not be null!");
 
 		this.query = query;
+		
+		assertSinglePageablePlaceholder();
+		assertSingleSortPlaceholder();
+		
 		this.queryBindParams = getBindParamsInQuery();
 	}
 
@@ -64,6 +77,36 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 		final Map<String, Object> bindVars,
 		final AqlQueryOptions options) {
 
+		extractBindVars(accessor, bindVars);
+
+		return prepareQuery(accessor);
+	}
+
+	@Override
+	protected boolean isCountQuery() {
+		return false;
+	}
+
+	@Override
+	protected boolean isExistsQuery() {
+		return false;
+	}
+
+	private String prepareQuery(final ArangoParameterAccessor accessor) {
+		if (accessor.getParameters().hasPageableParameter()) {
+			final String pageableClause = AqlUtils.buildPageableClause(accessor.getPageable());
+			return PAGEABLE_PLACEHOLDER_PATTERN.matcher(query).replaceFirst(pageableClause);
+		}
+
+		if (accessor.getParameters().hasSortParameter()) {
+			final String sortClause = AqlUtils.buildSortClause(accessor.getSort());
+			return SORT_PLACEHOLDER_PATTERN.matcher(query).replaceFirst(sortClause);
+		}
+
+		return query;
+	}
+
+	private void extractBindVars(final ArangoParameterAccessor accessor, final Map<String, Object> bindVars) {
 		final Map<String, Object> bindVarsInParams = accessor.getBindVars();
 		if (bindVarsInParams != null) {
 			bindVars.putAll(bindVarsInParams);
@@ -87,18 +130,6 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 				}
 			}
 		}
-
-		return query;
-	}
-
-	@Override
-	protected boolean isCountQuery() {
-		return false;
-	}
-
-	@Override
-	protected boolean isExistsQuery() {
-		return false;
 	}
 
 	private Set<String> getBindParamsInQuery() {
@@ -138,6 +169,30 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 			fixedQuery.append(query.charAt(i));
 		}
 		return fixedQuery.toString();
+	}
+
+	private void assertSinglePageablePlaceholder() {
+		if (method.getParameters().hasPageableParameter()) {
+			int firstOccurrence = query.indexOf(PAGEABLE_PLACEHOLDER);
+			int secondOccurrence = query.indexOf(PAGEABLE_PLACEHOLDER, firstOccurrence + PAGEABLE_PLACEHOLDER.length());
+
+			Assert.isTrue(firstOccurrence > -1 && secondOccurrence < 0,
+				String.format(
+					"Native query with Pageable param must contain exactly one pageable placeholder (%s)! Offending method: %s",
+					PAGEABLE_PLACEHOLDER, method));
+		}
+	}
+
+	private void assertSingleSortPlaceholder() {
+		if (method.getParameters().hasSortParameter()) {
+			int firstOccurrence = query.indexOf(SORT_PLACEHOLDER);
+			int secondOccurrence = query.indexOf(SORT_PLACEHOLDER, firstOccurrence + SORT_PLACEHOLDER.length());
+
+			Assert.isTrue(firstOccurrence > -1 && secondOccurrence < 0,
+				String.format(
+					"Native query with Sort param must contain exactly one sort placeholder (%s)! Offending method: %s",
+					SORT_PLACEHOLDER, method));
+		}
 	}
 
 }

--- a/src/test/java/com/arangodb/springframework/core/util/AqlUtilsTest.java
+++ b/src/test/java/com/arangodb/springframework/core/util/AqlUtilsTest.java
@@ -1,0 +1,196 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * 
+ * @author Christian Lechner
+ */
+public class AqlUtilsTest {
+
+	@Test
+	public void buildLimitClauseTest() {
+		assertThat(AqlUtils.buildLimitClause(Pageable.unpaged()), is(""));
+		assertThat(AqlUtils.buildLimitClause(PageRequest.of(0, 1)), is("LIMIT 0, 1"));
+		assertThat(AqlUtils.buildLimitClause(PageRequest.of(10, 20)), is("LIMIT 200, 20"));
+	}
+
+	@Test
+	public void buildPageableClauseTest() {
+		// Special cases
+		assertThat(AqlUtils.buildPageableClause(Pageable.unpaged()), is(""));
+
+		// Paging without sort
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(0, 1)), is("LIMIT 0, 1"));
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(5, 10)), is("LIMIT 50, 10"));
+
+		// Paging with sort
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(2, 10, Direction.ASC, "property")),
+			is("SORT `property` ASC LIMIT 20, 10"));
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(2, 10, Direction.ASC, "property"), "var"),
+			is("SORT `var`.`property` ASC LIMIT 20, 10"));
+
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(2, 10, Direction.DESC, "property", "property2")),
+			is("SORT `property` DESC, `property2` DESC LIMIT 20, 10"));
+		assertThat(AqlUtils.buildPageableClause(PageRequest.of(2, 10, Direction.DESC, "property", "property2"), "var"),
+			is("SORT `var`.`property` DESC, `var`.`property2` DESC LIMIT 20, 10"));
+
+		assertThat(
+			AqlUtils.buildPageableClause(
+				PageRequest.of(2, 10, Sort.by("ascProp").and(Sort.by(Direction.DESC, "descProp")))),
+			is("SORT `ascProp` ASC, `descProp` DESC LIMIT 20, 10"));
+		assertThat(
+			AqlUtils.buildPageableClause(
+				PageRequest.of(2, 10, Sort.by("ascProp").and(Sort.by(Direction.DESC, "descProp"))), "var"),
+			is("SORT `var`.`ascProp` ASC, `var`.`descProp` DESC LIMIT 20, 10"));
+	}
+
+	@Test
+	public void buildSortClauseTest() {
+		// Special cases
+		assertThat(AqlUtils.buildSortClause(Sort.unsorted()), is(""));
+
+		// Others
+		assertThat(AqlUtils.buildSortClause(Sort.by("property")), is("SORT `property` ASC"));
+		assertThat(AqlUtils.buildSortClause(Sort.by("property"), "var"), is("SORT `var`.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property")), is("SORT `property` DESC"));
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property"), "var"),
+			is("SORT `var`.`property` DESC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property", "property2")),
+			is("SORT `property` DESC, `property2` DESC"));
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property", "property2"), "var"),
+			is("SORT `var`.`property` DESC, `var`.`property2` DESC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property").and(Sort.by("property2"))),
+			is("SORT `property` DESC, `property2` ASC"));
+		assertThat(AqlUtils.buildSortClause(Sort.by(Direction.DESC, "property").and(Sort.by("property2")), "var"),
+			is("SORT `var`.`property` DESC, `var`.`property2` ASC"));
+	}
+
+	@Test
+	public void sortClauseEscapingTest() {
+		assertThat(AqlUtils.buildSortClause(Sort.by("property")), is("SORT `property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`property`")), is("SORT `property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`pro\\`perty\\``")), is("SORT `pro\\`perty\\`` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`dont.split.property`")), is("SORT `dont.split.property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("property.`property`")), is("SORT `property`.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("property.`.`.`property`")),
+			is("SORT `property`.`.`.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("property.\\.property")),
+			is("SORT `property`.`\\\\`.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("property.\\\\`.property")),
+			is("SORT `property`.`\\\\\\``.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`property.\\`.property`")),
+			is("SORT `property.\\`.property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`property.\\``.property")),
+			is("SORT `property.\\``.`property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("`property..property`")), is("SORT `property..property` ASC"));
+
+		assertThat(AqlUtils.buildSortClause(Sort.by("property\\. REMOVE doc IN collection //")),
+			is("SORT `property\\\\`.` REMOVE doc IN collection //` ASC"));
+
+		// Illegal sort properties
+
+		try {
+			AqlUtils.buildSortClause(Sort.by(".property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("property."));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("property..property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("property.`property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("pro`perty.property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("`property``.property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("`property```.property"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("`property.`\\`.property`"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("`property.`\\``.property`"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			AqlUtils.buildSortClause(Sort.by("`property`.\\``.property`"));
+			Assert.fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+	}
+
+}

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -150,9 +150,15 @@ public interface CustomerRepository extends ArangoRepository<Customer> {
 
 	Customer[] findByNameOrderBySurnameAsc(Sort sort, String name);
 
+	@Query("FOR c IN customer FILTER c.name == @1 #sort RETURN c")
+	List<Customer> findByNameWithSort(Sort sort, String name);
+
 	// PAGEABLE
 
 	Page<Customer> readByNameAndSurname(Pageable pageable, String name, AqlQueryOptions options, String surname);
+
+	@Query("FOR c IN customer FILTER c.name == @1 AND c.surname == @2 #pageable RETURN c")
+	Page<Customer> findByNameAndSurnameWithPageable(Pageable pageable, String name, String surname);
 
 	// GEO_RESULT, GEO_RESULTS, GEO_PAGE
 

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -2,6 +2,7 @@ package com.arangodb.springframework.repository.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIn.isOneOf;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -13,6 +14,11 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.arangodb.ArangoCursor;
@@ -190,6 +196,38 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		for (CustomerNameProjection proj : retrieved) {
 			assertThat(proj.getName(), isOneOf(john.getName(), bob.getName()));
 		}
+	}
+
+	@Test
+	public void pageableTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		repository.save(new Customer("A", "A", 0));
+		repository.save(new Customer("A", "A", 1));
+		toBeRetrieved.add(new Customer("A", "A", 2));
+		repository.save(new Customer("B", "B", 3));
+		toBeRetrieved.add(new Customer("A", "A", 4));
+		repository.save(new Customer("A", "A", 5));
+		repository.saveAll(toBeRetrieved);
+		final Pageable pageable = PageRequest.of(1, 2, Sort.by("c.age"));
+		final Page<Customer> retrieved = repository.findByNameAndSurnameWithPageable(pageable, "A", "A");
+		assertThat(retrieved.getTotalElements(), is(5L));
+		assertThat(retrieved.getTotalPages(), is(3));
+		assertThat(retrieved.getContent(), is(toBeRetrieved));
+	}
+
+	@Test
+	public void sortTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		toBeRetrieved.add(new Customer("A", "B", 2));
+		toBeRetrieved.add(new Customer("A", "B", 3));
+		toBeRetrieved.add(new Customer("A", "A", 1));
+		repository.save(toBeRetrieved.get(1));
+		repository.save(toBeRetrieved.get(0));
+		repository.save(toBeRetrieved.get(2));
+		repository.save(new Customer("C", "C", 0));
+		final List<Customer> retrieved = repository
+				.findByNameWithSort(Sort.by(Direction.DESC, "c.surname").and(Sort.by("c.age")), "A");
+		assertThat(retrieved, is(toBeRetrieved));
 	}
 
 }


### PR DESCRIPTION
I'm opening this PR although it's not finished yet. I want to discuss something:

When building the sort string (`DerivedQueryCreator.buildSortString(sort)`) the property argument is directly embedded into the query. If the sorting properties are user supplied values, this could provide the possibility to perform an AQL injection.

Example:
```java
public interface CustomerRepository extends ArangoRepository<Customer> {
    Customer[] findByName(Sort sort, String name);
}

String sort = "age REMOVE e IN customer SORT e.age";  // user provided value
// executes query: 
// FOR e IN customer FILTER e.name == @0 
// SORT e.age REMOVE e IN customer SORT e.age ASC
// RETURN e
final Customer[] retrieved = repository.findByName(Sort.by(sort), "Name");
```

Shouldn't there be some mechanism that this is not possible?
