### PR TITLE
Allow override of CRUD methods of ArangoRepository with @Query

### DIFF
--- a/src/main/java/com/arangodb/springframework/annotation/Query.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Query.java
@@ -25,11 +25,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.data.annotation.QueryAnnotation;
+
 /**
- * Created by F625633 on 12/07/2017.
+ * 
+ * @author Audrius Malele
+ * @author Mark McCormick
+ * @author Mark Vollmary
+ * @author Christian Lechner
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@QueryAnnotation
 public @interface Query {
 
 	/**

--- a/src/test/java/com/arangodb/springframework/repository/OverriddenCrudMethodsRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/OverriddenCrudMethodsRepository.java
@@ -1,0 +1,37 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.repository;
+
+import com.arangodb.springframework.annotation.Query;
+import com.arangodb.springframework.testdata.Customer;
+
+/**
+ * 
+ * @author Christian Lechner
+ *
+ */
+public interface OverriddenCrudMethodsRepository extends ArangoRepository<Customer> {
+
+	@Override
+	@Query("RETURN NULL")
+	Iterable<Customer> findAll();
+
+}

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -1,6 +1,7 @@
 package com.arangodb.springframework.repository.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsIn.isOneOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -8,12 +9,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +30,7 @@ import com.arangodb.entity.BaseDocument;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.core.convert.DBDocumentEntity;
 import com.arangodb.springframework.repository.AbstractArangoRepositoryTest;
+import com.arangodb.springframework.repository.OverriddenCrudMethodsRepository;
 import com.arangodb.springframework.testdata.Customer;
 import com.arangodb.springframework.testdata.CustomerNameProjection;
 
@@ -39,6 +43,9 @@ import com.arangodb.springframework.testdata.CustomerNameProjection;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
+
+	@Autowired
+	protected OverriddenCrudMethodsRepository overriddenRepository;
 
 	@Test
 	public void findOneByIdAqlWithNamedParameterTest() {
@@ -228,6 +235,14 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		final List<Customer> retrieved = repository
 				.findByNameWithSort(Sort.by(Direction.DESC, "c.surname").and(Sort.by("c.age")), "A");
 		assertThat(retrieved, is(toBeRetrieved));
+	}
+
+	@Test
+	public void overriddenCrudMethodsTest() {
+		overriddenRepository.saveAll(customers);
+		Iterator<Customer> customers = overriddenRepository.findAll().iterator();
+		assertThat(customers.hasNext(), is(true));
+		assertThat(customers.next(), is(nullValue()));
 	}
 
 }


### PR DESCRIPTION
With this change, users can override the CRUD methods defined in `ArangoRepository` by using the `@Query` annotation:

```java
public interface SomeRepo extends ArangoRepository<Customer> {
    @Override
    @Query("RETURN NULL")
    Iterable<Customer> findAll();
}
```