### PR TITLE
Proxy class support for converter

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/LazyLoadingProxy.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/LazyLoadingProxy.java
@@ -1,0 +1,44 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.convert.resolver;
+
+/**
+ * Allows identification of proxy classes and retrieval of the wrapped entity.
+ * 
+ * @author Christian Lechner
+ */
+public interface LazyLoadingProxy {
+
+	/**
+	 * Retrieves the entity wrapped by this proxy.
+	 *
+	 * @return
+	 */
+	Object getEntity();
+
+	/**
+	 * Returns the reference id of this proxy, which is the _id of the wrapped entity.
+	 *
+	 * @return
+	 */
+	String getRefId();
+
+}


### PR DESCRIPTION
- Support serialization of proxy classes that were created while deserializing lazy references
- Add `ensureResolved()` method to `AbstractResolver.ProxyInterceptor` so that `synchronized resolve()` method is only accessed when the value is not already resolved