### PR TITLE
move ResolverFactory impl from anon. class to own class

### DIFF
--- a/src/main/java/com/arangodb/springframework/config/AbstractArangoConfiguration.java
+++ b/src/main/java/com/arangodb/springframework/config/AbstractArangoConfiguration.java
@@ -20,9 +20,7 @@
 
 package com.arangodb.springframework.config;
 
-import java.lang.annotation.Annotation;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.context.annotation.Bean;
@@ -32,24 +30,14 @@ import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 
 import com.arangodb.ArangoDB;
-import com.arangodb.ArangoDBException;
-import com.arangodb.springframework.annotation.From;
-import com.arangodb.springframework.annotation.Ref;
-import com.arangodb.springframework.annotation.Relations;
-import com.arangodb.springframework.annotation.To;
 import com.arangodb.springframework.core.ArangoOperations;
 import com.arangodb.springframework.core.convert.ArangoConverter;
 import com.arangodb.springframework.core.convert.ArangoCustomConversions;
 import com.arangodb.springframework.core.convert.ArangoTypeMapper;
 import com.arangodb.springframework.core.convert.DefaultArangoConverter;
 import com.arangodb.springframework.core.convert.DefaultArangoTypeMapper;
-import com.arangodb.springframework.core.convert.resolver.FromResolver;
-import com.arangodb.springframework.core.convert.resolver.RefResolver;
-import com.arangodb.springframework.core.convert.resolver.ReferenceResolver;
-import com.arangodb.springframework.core.convert.resolver.RelationResolver;
-import com.arangodb.springframework.core.convert.resolver.RelationsResolver;
+import com.arangodb.springframework.core.convert.resolver.DefaultResolverFactory;
 import com.arangodb.springframework.core.convert.resolver.ResolverFactory;
-import com.arangodb.springframework.core.convert.resolver.ToResolver;
 import com.arangodb.springframework.core.mapping.ArangoMappingContext;
 import com.arangodb.springframework.core.template.ArangoTemplate;
 
@@ -109,40 +97,8 @@ public abstract class AbstractArangoConfiguration {
 		return new DefaultArangoTypeMapper(typeKey(), arangoMappingContext());
 	}
 
-	protected ResolverFactory resolverFactory() {
-		return new ResolverFactory() {
-			@SuppressWarnings("unchecked")
-			@Override
-			public <A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(final A annotation) {
-				ReferenceResolver<A> resolver = null;
-				try {
-					if (annotation instanceof Ref) {
-						resolver = (ReferenceResolver<A>) new RefResolver(arangoTemplate());
-					}
-				} catch (final Exception e) {
-					throw new ArangoDBException(e);
-				}
-				return Optional.ofNullable(resolver);
-			}
-
-			@SuppressWarnings("unchecked")
-			@Override
-			public <A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(final A annotation) {
-				RelationResolver<A> resolver = null;
-				try {
-					if (annotation instanceof From) {
-						resolver = (RelationResolver<A>) new FromResolver(arangoTemplate());
-					} else if (annotation instanceof To) {
-						resolver = (RelationResolver<A>) new ToResolver(arangoTemplate());
-					} else if (annotation instanceof Relations) {
-						resolver = (RelationResolver<A>) new RelationsResolver(arangoTemplate());
-					}
-				} catch (final Exception e) {
-					throw new ArangoDBException(e);
-				}
-				return Optional.ofNullable(resolver);
-			}
-		};
+	protected ResolverFactory resolverFactory() throws Exception {
+		return new DefaultResolverFactory(arangoTemplate());
 	}
 
 }

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/DefaultResolverFactory.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/DefaultResolverFactory.java
@@ -25,7 +25,7 @@ public class DefaultResolverFactory implements ResolverFactory {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(final Class<A> annotation) {
+	public <A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(final A annotation) {
 		ReferenceResolver<A> resolver = null;
 		if (Ref.class.equals(annotation)) {
 			resolver = (ReferenceResolver<A>) refResolver;
@@ -35,7 +35,7 @@ public class DefaultResolverFactory implements ResolverFactory {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(final Class<A> annotation) {
+	public <A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(final A annotation) {
 		RelationResolver<A> resolver = null;
 		if (From.class.equals(annotation)) {
 			resolver = (RelationResolver<A>) fromResolver;

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/DefaultResolverFactory.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/DefaultResolverFactory.java
@@ -1,0 +1,50 @@
+package com.arangodb.springframework.core.convert.resolver;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import com.arangodb.springframework.annotation.From;
+import com.arangodb.springframework.annotation.Ref;
+import com.arangodb.springframework.annotation.Relations;
+import com.arangodb.springframework.annotation.To;
+import com.arangodb.springframework.core.ArangoOperations;
+
+public class DefaultResolverFactory implements ResolverFactory {
+
+	private final RefResolver refResolver;
+	private final RelationsResolver relationsResolver;
+	private final FromResolver fromResolver;
+	private final ToResolver toResolver;
+
+	public DefaultResolverFactory(final ArangoOperations template) {
+		refResolver = new RefResolver(template);
+		relationsResolver = new RelationsResolver(template);
+		fromResolver = new FromResolver(template);
+		toResolver = new ToResolver(template);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(final Class<A> annotation) {
+		ReferenceResolver<A> resolver = null;
+		if (Ref.class.equals(annotation)) {
+			resolver = (ReferenceResolver<A>) refResolver;
+		}
+		return Optional.ofNullable(resolver);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(final Class<A> annotation) {
+		RelationResolver<A> resolver = null;
+		if (From.class.equals(annotation)) {
+			resolver = (RelationResolver<A>) fromResolver;
+		} else if (To.class.equals(annotation)) {
+			resolver = (RelationResolver<A>) toResolver;
+		} else if (Relations.class.equals(annotation)) {
+			resolver = (RelationResolver<A>) relationsResolver;
+		}
+		return Optional.ofNullable(resolver);
+	}
+
+}

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/ResolverFactory.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/ResolverFactory.java
@@ -29,8 +29,8 @@ import java.util.Optional;
  */
 public interface ResolverFactory {
 
-	<A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(A annotation);
+	<A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(Class<A> annotation);
 
-	<A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(A annotation);
+	<A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(Class<A> annotation);
 
 }

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/ResolverFactory.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/ResolverFactory.java
@@ -29,8 +29,8 @@ import java.util.Optional;
  */
 public interface ResolverFactory {
 
-	<A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(Class<A> annotation);
+	<A extends Annotation> Optional<ReferenceResolver<A>> getReferenceResolver(A annotation);
 
-	<A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(Class<A> annotation);
+	<A extends Annotation> Optional<RelationResolver<A>> getRelationResolver(A annotation);
 
 }


### PR DESCRIPTION
Changelog:
- move `ResolverFactory` implementation from anonymous class inside `AbstractArangoConfiguration` to own class
- cache resolver instances