### PR TITLE
fix for query by example: REGEX_TEST changed to LIKE

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/ArangoExampleConverter.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoExampleConverter.java
@@ -105,23 +105,24 @@ public class ArangoExampleConverter<T> {
 					: (specifier.getIgnoreCase() == null ? false : specifier.getIgnoreCase());
 			final ExampleMatcher.StringMatcher stringMatcher = (specifier == null
 					|| specifier.getStringMatcher() == ExampleMatcher.StringMatcher.DEFAULT)
-							? example.getMatcher().getDefaultStringMatcher() : specifier.getStringMatcher();
+							? example.getMatcher().getDefaultStringMatcher()
+							: specifier.getStringMatcher();
 			final String string = (String) value;
-			clause = String.format("REGEX_TEST(e.%s, @%s, %b)", fullPath, binding, ignoreCase);
+			clause = String.format("LIKE(e.%s, @%s, %b)", fullPath, binding, ignoreCase);
 			switch (stringMatcher) {
 			case STARTING:
-				value = "^" + escape(string);
+				value = escape(string) + "%";
 				break;
 			case ENDING:
-				value = escape(string) + "$";
+				value = "%" + escape(string);
 				break;
 			case CONTAINING:
-				value = escape(string);
+				value = "%" + escape(string) + "%";
 				break;
 			case DEFAULT:
 			case EXACT:
 			default:
-				value = "^" + escape(string) + "$";
+				value = escape(string);
 				break;
 			}
 		} else {
@@ -137,17 +138,8 @@ public class ArangoExampleConverter<T> {
 
 	static {
 		SPECIAL_CHARACTERS.add('\\');
-		SPECIAL_CHARACTERS.add('.');
-		SPECIAL_CHARACTERS.add('?');
-		SPECIAL_CHARACTERS.add('[');
-		SPECIAL_CHARACTERS.add(']');
-		SPECIAL_CHARACTERS.add('*');
-		SPECIAL_CHARACTERS.add('{');
-		SPECIAL_CHARACTERS.add('}');
-		SPECIAL_CHARACTERS.add('(');
-		SPECIAL_CHARACTERS.add(')');
-		SPECIAL_CHARACTERS.add('^');
-		SPECIAL_CHARACTERS.add('$');
+		SPECIAL_CHARACTERS.add('_');
+		SPECIAL_CHARACTERS.add('%');
 	}
 
 	private static String escape(final String string) {

--- a/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
@@ -341,4 +341,34 @@ public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
 		assertThat(retrieved.isPresent(), is(true));
 		assertThat(retrieved.get().getName(), is("name"));
 	}
+
+	@Test
+	public void plusSignExampleTest() {
+		String NAME = "Abc+Def";
+		final Customer entity = new Customer(NAME, "surname", 10);
+		repository.save(entity);
+
+		final Customer probe = new Customer();
+		probe.setName(NAME);
+		probe.setAge(10);
+		final Example<Customer> example = Example.of(probe);
+		final Optional<Customer> retrieved = repository.findOne(example);
+		assertThat(retrieved.isPresent(), is(true));
+		assertThat(retrieved.get().getName(), is(NAME));
+	}
+
+	@Test
+	public void exampleWithLikeAndEscapingTest() {
+		String NAME = "Abc+Def";
+		final Customer entity = new Customer(NAME, "surname", 10);
+		repository.save(entity);
+
+		final Customer probe = new Customer();
+		probe.setName("Abc+De%");
+		probe.setAge(10);
+		final Example<Customer> example = Example.of(probe);
+		final Optional<Customer> retrieved = repository.findOne(example);
+		assertThat(retrieved.isPresent(), is(false));
+	}
+
 }


### PR DESCRIPTION
The query by example feature is broken in the current arangodb-spring-data implementation. The plus sign (+) is not escaped, so string values containing this sign cannot be found by such a query. See my plusSignExampleTest JUnit test.
In this fix I'm using LIKE instead of REGEX_TEST, which I think is much faster and there are much fewer characters to escape.