### PR TITLE
Fix issue preventing the use of multiple edge entities in @Relations

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/RelationsResolver.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/RelationsResolver.java
@@ -71,20 +71,20 @@ public class RelationsResolver extends AbstractResolver<Relations> implements Re
 		final Relations annotation,
 		final boolean limit) {
 
+		final String edges = Arrays.stream(annotation.edges()).map(e -> template.collection(e).name())
+				.collect(Collectors.joining(","));
+
 		final String query = String.format(
-			"WITH @@vertex FOR v IN %d .. %d %s @start @@edges OPTIONS {bfs: true, uniqueVertices: \"global\"} %s RETURN v", //
+			"WITH @@vertex FOR v IN %d .. %d %s @start %s OPTIONS {bfs: true, uniqueVertices: \"global\"} %s RETURN v", //
 			Math.max(1, annotation.minDepth()), //
 			Math.max(1, annotation.maxDepth()), //
 			annotation.direction(), //
+			edges, //
 			limit ? "LIMIT 1" : "");
-
-		final String edges = Arrays.stream(annotation.edges()).map(e -> template.collection(e).name())
-				.collect(Collectors.joining(","));
 
 		final Map<String, Object> bindVars = new MapBuilder()//
 				.put("start", id) //
 				.put("@vertex", type) //
-				.put("@edges", edges) //
 				.get();
 
 		return template.query(query, bindVars, type);

--- a/src/test/java/com/arangodb/springframework/core/mapping/RelationsMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/RelationsMappingTest.java
@@ -218,4 +218,43 @@ public class RelationsMappingTest extends AbstractArangoTest {
 		assertThat(document.value.getId(), is(vertex.id));
 
 	}
+
+	static class AnotherBasicEdgeTestEntity extends BasicEdgeTestEntity {
+		public AnotherBasicEdgeTestEntity() {
+			super();
+		}
+
+		public AnotherBasicEdgeTestEntity(final BasicTestEntity from, final BasicTestEntity to)
+		{
+			super(from, to);
+		}
+	}
+
+	static class MultipleEdgeTypeRelationsTestEntity extends BasicTestEntity {
+		@Relations(edges = {BasicEdgeTestEntity.class, AnotherBasicEdgeTestEntity.class}, maxDepth = 2)
+		private Collection<BasicTestEntity> entities;
+	}
+
+	@Test
+	public void multipleEdgeTypeRelations() {
+		final BasicTestEntity e1 = new BasicTestEntity();
+		template.insert(e1);
+		final BasicTestEntity e2 = new BasicTestEntity();
+		template.insert(e2);
+		final MultipleEdgeTypeRelationsTestEntity e0 = new MultipleEdgeTypeRelationsTestEntity();
+		template.insert(e0);
+		template.insert(new BasicEdgeTestEntity(e0, e1));
+		template.insert(new AnotherBasicEdgeTestEntity(e1, e2));
+
+		final MultipleEdgeTypeRelationsTestEntity document = template
+				.find(e0.id, MultipleEdgeTypeRelationsTestEntity.class).get();
+		assertThat(document, is(notNullValue()));
+		assertThat(document.entities, is(notNullValue()));
+		assertThat(document.entities.size(), is(2));
+		for (final BasicTestEntity e : document.entities) {
+			assertThat(e, instanceOf(BasicTestEntity.class));
+			assertThat(e.getId(), is(notNullValue()));
+			assertThat(e.getId(), is(isOneOf(e1.getId(), e2.getId())));
+		}
+	}
 }


### PR DESCRIPTION
The `Relations` annotation accepts multiple edge entities. This resulted in an invalid AQL query being generated.

This fix adds a test for using multiple edge entities with `Relations` and working AQL query generation.