### PR TITLE
Doc improvement: Link from relations to from / to

### DIFF
--- a/docs/Drivers/SpringData/Reference/Mapping/Relations.md
+++ b/docs/Drivers/SpringData/Reference/Mapping/Relations.md
@@ -17,4 +17,8 @@ public class Relation {
 }
 ```
 
+**Edge Documents**
+
+To get a collection of `Relation` documents instead of the target `Person`, use `@From()` / `@To()` annotations [documented here](Document.md#annotation-from-and-to). 
+
 **Note**: Since arangodb-spring-data 3.0.0 the annotation `@Relations` also work on non-collection/non-array fields. If multiple documents are linked with the entity, it is not guaranteed that the same document is returned every time. Use at your own risk.


### PR DESCRIPTION
Searched a while, therefore linked in `Relations.md` where i initially looked for it.