### PR TITLE
DefaultArangoConverter: fix for #147

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
@@ -166,7 +166,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 			return readMap(typeToUse, source);
 		}
 
-		if (ClassTypeInformation.OBJECT.equals(typeToUse)) {
+		if (!source.isArray() && ClassTypeInformation.OBJECT.equals(typeToUse)) {
 			return readMap(ClassTypeInformation.MAP, source);
 		}
 
@@ -174,8 +174,12 @@ public class DefaultArangoConverter implements ArangoConverter {
 			return readArray(typeToUse, source);
 		}
 
-		if (typeToUse.isCollectionLike() || ClassTypeInformation.OBJECT.equals(typeToUse)) {
+		if (typeToUse.isCollectionLike()) {
 			return readCollection(typeToUse, source);
+		}
+
+		if (ClassTypeInformation.OBJECT.equals(typeToUse)) {
+			return readCollection(ClassTypeInformation.COLLECTION, source);
 		}
 
 		final ArangoPersistentEntity<?> entity = context.getRequiredPersistentEntity(rawTypeToUse);

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -30,6 +30,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -558,6 +560,17 @@ public class GeneralMappingTest extends AbstractArangoTest {
 		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
 		assertThat(find.isPresent(), is(true));
 		assertThat(find.get().value, is(map));
+	}
+
+	@Test
+	public void readObjectFieldFromCollectionLike() {
+		final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
+		final Collection<String> collection = Collections.singleton("test");
+		entity.value = collection;
+		template.insert(entity);
+		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
+		assertThat(find.isPresent(), is(true));
+		assertThat(find.get().value, is(collection));
 	}
 
 	@Test


### PR DESCRIPTION
Handle case when resolved "type to use" is "object" and VelocyPack "source" is "array" in DefaultArangoConverter.
Fixes #147 