### PR TITLE
Create the collection in Multi Tenancy on findOne

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -364,7 +364,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 		final Pageable pageable,
 		@Nullable final Example<S> example,
 		final Map<String, Object> bindVars) {
-
+		arangoOperations.collection(domainClass);
 		final String query = String.format("FOR e IN %s %s %s RETURN e", getCollectionName(),
 			buildFilterClause(example, bindVars), buildPageableClause(pageable, "e"));
 

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -329,6 +329,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> long count(final Example<S> example) {
+		arangoOperations.collection(domainClass);
 		final Map<String, Object> bindVars = new HashMap<>();
 		final String predicate = exampleConverter.convertExampleToPredicate(example, bindVars);
 		final String filter = predicate.length() == 0 ? "" : " FILTER " + predicate;
@@ -354,7 +355,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 		final Sort sort,
 		@Nullable final Example<S> example,
 		final Map<String, Object> bindVars) {
-
+		arangoOperations.collection(domainClass);
 		final String query = String.format("FOR e IN %s %s %s RETURN e", getCollectionName(),
 			buildFilterClause(example, bindVars), buildSortClause(sort, "e"));
 		return arangoOperations.query(query, bindVars, null, domainClass);

--- a/src/test/java/com/arangodb/springframework/ArangoMultiTenancyRepositoryTestConfiguration.java
+++ b/src/test/java/com/arangodb/springframework/ArangoMultiTenancyRepositoryTestConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2017 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+import com.arangodb.ArangoDB;
+import com.arangodb.springframework.annotation.EnableArangoRepositories;
+import com.arangodb.springframework.config.ArangoConfiguration;
+import com.arangodb.springframework.core.mapping.CustomMappingTest;
+
+/**
+ *
+ * @author Paulo Ferreira
+ */
+@Configuration
+@ComponentScan("com.arangodb.springframework.component")
+@EnableArangoRepositories(basePackages = {
+		"com.arangodb.springframework.repository",
+		"com.arangodb.springframework.example.polymorphic.repository",
+		"com.arangodb.springframework.debug.repository"},
+						  namedQueriesLocation = "classpath*:arango-named-queries-test.properties")
+public class ArangoMultiTenancyRepositoryTestConfiguration implements ArangoConfiguration {
+
+	public static final String DB = "spring-test-db";
+
+	@Override
+	public ArangoDB.Builder arango() {
+		return new ArangoDB.Builder();
+	}
+
+	@Override
+	public String database() {
+		return DB + "#{tenantProvider.getId()}";
+	}
+
+	@Override
+	public Collection<Converter<?, ?>> customConverters() {
+		final Collection<Converter<?, ?>> converters = new ArrayList<>();
+		converters.add(new CustomMappingTest.CustomVPackReadTestConverter());
+		converters.add(new CustomMappingTest.CustomVPackWriteTestConverter());
+		converters.add(new CustomMappingTest.CustomDBEntityReadTestConverter());
+		converters.add(new CustomMappingTest.CustomDBEntityWriteTestConverter());
+		return converters;
+	}
+
+}

--- a/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
@@ -75,7 +75,8 @@ public class MultiTenancyDBLevelRepositoryTest {
 		IdTestEntity<String> entity = new IdTestEntity<>();
 		entity.setId("MyId");
 		Example<IdTestEntity<String>> example = Example.of(entity);
-		assertThat(idTestRepository.findOne(example).isEmpty(), is(true));
+		Optional<IdTestEntity<String>> result = idTestRepository.findOne(example);
+		assertThat(result.isPresent(), is(false));
 	}
 
 	@Before

--- a/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
@@ -23,6 +23,8 @@ package com.arangodb.springframework.core.mapping;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Optional;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/MultiTenancyDBLevelRepositoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2018 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.core.mapping;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Example;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.arangodb.springframework.ArangoMultiTenancyRepositoryTestConfiguration;
+import com.arangodb.springframework.component.TenantProvider;
+import com.arangodb.springframework.core.ArangoOperations;
+import com.arangodb.springframework.repository.IdTestRepository;
+import com.arangodb.springframework.testdata.IdTestEntity;
+
+/**
+ * @author Paulo Ferreira
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { ArangoMultiTenancyRepositoryTestConfiguration.class })
+public class MultiTenancyDBLevelRepositoryTest {
+
+	private static final String TENANT00 = "tenant00";
+
+	@Autowired
+	protected ArangoOperations template;
+
+	@Autowired
+	TenantProvider tenantProvider;
+
+	@Autowired
+	IdTestRepository<String> idTestRepository;
+	
+	/*
+	 * For some reason, findAll already creates the collection by itself
+	 */
+
+	@Test
+	public void dbFindAll() {
+		tenantProvider.setId(TENANT00);
+		assertThat(idTestRepository.findAll().iterator().hasNext(), is(false));
+	}
+
+	@Test
+	public void dbFindOne() {
+		tenantProvider.setId(TENANT00);
+		IdTestEntity<String> entity = new IdTestEntity<>();
+		entity.setId("MyId");
+		Example<IdTestEntity<String>> example = Example.of(entity);
+		assertThat(idTestRepository.findOne(example).isEmpty(), is(true));
+	}
+
+	@Before
+	@After
+	public void cleanup() {
+		tenantProvider.setId(TENANT00);
+		template.dropDatabase();
+	}
+
+}


### PR DESCRIPTION
Gentlemen, please accept my correction.

This is the case where explaining the problem is much more difficult than solving it. :)

I use ArangoDB with Multi Tenancy together with Spring Repository. I found that when querying a Collection that doesn't exist with FindOne, it returns that the collection doesn't exist. Which makes sense, but other things like the native findAll, create the collection instead of giving the error and return empty. So findOne, which should return an Optional<T> .empty(), but it would return an Execption. Creating an inconsistency.

In this way, we had an inconsistency. Either it should always come back empty, or it should always come back Execption.

Well, the solution is just one line, do the Collection check within the custom find method. The creation of the Collection is already native if it does not exist when checking.

I also created a configuration class and a test class for using the repository. But they are completely optional.

Thank you very much for your attention.