### PR TITLE
Allow usage uuid, long etc for @id without class cast exception

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -717,7 +717,13 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		final PersistentPropertyAccessor<?> accessor = entity.getPropertyAccessor(value);
 		final ArangoPersistentProperty idProperty = entity.getIdProperty();
 		if (idProperty != null && !idProperty.isImmutable()) {
-			accessor.setProperty(idProperty, documentEntity.getKey());
+			if(idProperty.getType().isAssignableFrom(documentEntity.getKey().getClass())) {
+				accessor.setProperty(idProperty, documentEntity.getKey());
+			}else{
+				if(converter.getConversionService().canConvert(documentEntity.getKey().getClass(),idProperty.getType())){
+					accessor.setProperty(idProperty,converter.getConversionService().convert(documentEntity.getKey(),idProperty.getType()));
+				}
+			}
 		}
 		entity.getArangoIdProperty().filter(arangoId -> !arangoId.isImmutable())
 				.ifPresent(arangoId -> accessor.setProperty(arangoId, documentEntity.getId()));

--- a/src/test/java/com/arangodb/springframework/debug/repository/LongEntityRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/debug/repository/LongEntityRepositoryTest.java
@@ -22,7 +22,6 @@ package com.arangodb.springframework.debug.repository;
 
 import com.arangodb.springframework.AbstractArangoTest;
 import com.arangodb.springframework.debug.repository.entity.LongEntity;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -40,7 +39,6 @@ public class LongEntityRepositoryTest extends AbstractArangoTest {
 	private LongEntityRepository repo;
 
 	@Test
-	@Ignore
 	public void save() {
 		LongEntity entity = new LongEntity();
 		entity.setId(1L);
@@ -51,6 +49,7 @@ public class LongEntityRepositoryTest extends AbstractArangoTest {
 
 		assertThat(saved, is(entity));
 		assertThat(fetched.isPresent(), is(true));
-		assertThat(fetched.get(), is(entity));
+		assertThat(fetched.get().getId(), is(entity.getId()));
+		assertThat(fetched.get().getValue(), is(entity.getValue()));
 	}
 }


### PR DESCRIPTION
Fix error with entity key, when @id of entity is not string. 
Use converter as workaround (this can fix https://github.com/arangodb/spring-data/issues/150 to)