### PR TITLE
repsert based on AQL UPSERT

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -486,7 +486,6 @@ public interface ArangoOperations {
 	 *            A representation of a single document
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
-	 *
 	 */
 	<T> void repsert(T value) throws DataAccessException;
 
@@ -494,8 +493,10 @@ public interface ArangoOperations {
 	 * Creates new documents from the given documents, unless there already exists. In that case it replaces the
 	 * documents.
 	 *
-	 * @param values      documents to save
-	 * @param entityClass The entity class which represents the collection
+	 * @param values
+	 *            A List of documents
+	 * @param entityClass
+	 *            The entity class which represents the collection
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
 	 */

--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -505,6 +505,8 @@ public interface ArangoOperations {
 	 * return {@param values: Iterable<T>} (same identical instances)
 	 * <p>
 	 * TODO: refactor use of generic
+	 * TODO: add Class<T> as argument, repository should know it from related entity information
+	 * 		 also in this way we keep the same fn signature as b4, so w/o breaking changes
 	 */
 	<T> void repsert(Iterable<? extends T> values) throws DataAccessException;
 

--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -487,9 +487,6 @@ public interface ArangoOperations {
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
 	 *
-	 * TODO:
-	 * return {@param value: T} (same identical instance)
-	 *
 	 */
 	<T> void repsert(T value) throws DataAccessException;
 
@@ -497,18 +494,12 @@ public interface ArangoOperations {
 	 * Creates new documents from the given documents, unless there already exists. In that case it replaces the
 	 * documents.
 	 *
-	 * @param values A List of documents
+	 * @param values      documents to save
+	 * @param entityClass The entity class which represents the collection
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
-	 * <p>
-	 * TODO:
-	 * return {@param values: Iterable<T>} (same identical instances)
-	 * <p>
-	 * TODO: refactor use of generic
-	 * TODO: add Class<T> as argument, repository should know it from related entity information
-	 * 		 also in this way we keep the same fn signature as b4, so w/o breaking changes
 	 */
-	<T> void repsert(Iterable<? extends T> values) throws DataAccessException;
+	<T> void repsert(Iterable<? extends T> values, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Checks whether the document exists by reading a single document head

--- a/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/ArangoOperations.java
@@ -20,25 +20,18 @@
 
 package com.arangodb.springframework.core;
 
-import java.util.Map;
-import java.util.Optional;
-
-import org.springframework.dao.DataAccessException;
-
 import com.arangodb.ArangoCursor;
 import com.arangodb.ArangoDB;
 import com.arangodb.entity.ArangoDBVersion;
 import com.arangodb.entity.DocumentEntity;
 import com.arangodb.entity.MultiDocumentEntity;
 import com.arangodb.entity.UserEntity;
-import com.arangodb.model.AqlQueryOptions;
-import com.arangodb.model.CollectionCreateOptions;
-import com.arangodb.model.DocumentCreateOptions;
-import com.arangodb.model.DocumentDeleteOptions;
-import com.arangodb.model.DocumentReadOptions;
-import com.arangodb.model.DocumentReplaceOptions;
-import com.arangodb.model.DocumentUpdateOptions;
+import com.arangodb.model.*;
 import com.arangodb.springframework.core.convert.ArangoConverter;
+import org.springframework.dao.DataAccessException;
+
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Interface that specifies a basic set of ArangoDB operations.
@@ -493,6 +486,10 @@ public interface ArangoOperations {
 	 *            A representation of a single document
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
+	 *
+	 * TODO:
+	 * return {@param value: T} (same identical instance)
+	 *
 	 */
 	<T> void repsert(T value) throws DataAccessException;
 
@@ -500,14 +497,16 @@ public interface ArangoOperations {
 	 * Creates new documents from the given documents, unless there already exists. In that case it replaces the
 	 * documents.
 	 *
-	 * @param value
-	 *            A List of documents
-	 * @param entityClass
-	 *            The entity class which represents the collection
+	 * @param values A List of documents
 	 * @throws DataAccessException
 	 * @since ArangoDB 3.4
+	 * <p>
+	 * TODO:
+	 * return {@param values: Iterable<T>} (same identical instances)
+	 * <p>
+	 * TODO: refactor use of generic
 	 */
-	<T> void repsert(Iterable<T> value, Class<T> entityClass) throws DataAccessException;
+	<T> void repsert(Iterable<? extends T> values) throws DataAccessException;
 
 	/**
 	 * Checks whether the document exists by reading a single document head

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -63,7 +63,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	}
 
 	/**
-	 * Saves the passed entity to the database using upsert from the template
+	 * Saves the passed entity to the database using repsert from the template
 	 *
 	 * @param entity
 	 *            the entity to be saved to the database
@@ -76,7 +76,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	}
 
 	/**
-	 * Saves the given iterable of entities to the database
+	 * Saves the given iterable of entities to the database using repsert from the template
 	 *
 	 * @param entities
 	 *            the iterable of entities to be saved to the database

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -84,7 +84,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> Iterable<S> saveAll(final Iterable<S> entities) {
-		arangoOperations.repsert(entities);
+		arangoOperations.repsert(entities, domainClass);
 		return entities;
 	}
 

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -20,29 +20,18 @@
 
 package com.arangodb.springframework.repository;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.StreamSupport;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Repository;
-
 import com.arangodb.ArangoCursor;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.core.ArangoOperations;
-import com.arangodb.springframework.core.ArangoOperations.UpsertStrategy;
 import com.arangodb.springframework.core.mapping.ArangoMappingContext;
 import com.arangodb.springframework.core.util.AqlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.*;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
 
 /**
  * The implementation of all CRUD, paging and sorting functionality in ArangoRepository from the Spring Data Commons
@@ -80,14 +69,9 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 *            the entity to be saved to the database
 	 * @return the updated entity with any id/key/rev saved
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public <S extends T> S save(final S entity) {
-		if (arangoOperations.getVersion().getVersion().compareTo("3.4.0") < 0) {
-			arangoOperations.upsert(entity, UpsertStrategy.REPLACE);
-		} else {
-			arangoOperations.repsert(entity);
-		}
+		arangoOperations.repsert(entity);
 		return entity;
 	}
 
@@ -98,15 +82,9 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 *            the iterable of entities to be saved to the database
 	 * @return the iterable of updated entities with any id/key/rev saved in each entity
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public <S extends T> Iterable<S> saveAll(final Iterable<S> entities) {
-		if (arangoOperations.getVersion().getVersion().compareTo("3.4.0") < 0) {
-			arangoOperations.upsert(entities, UpsertStrategy.UPDATE);
-		} else {
-			final S first = StreamSupport.stream(entities.spliterator(), false).findFirst().get();
-			arangoOperations.repsert(entities, (Class<S>) first.getClass());
-		}
+		arangoOperations.repsert(entities);
 		return entities;
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/ShardedCollectionRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ShardedCollectionRepositoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.repository;
+
+import com.arangodb.springframework.AbstractArangoTest;
+import com.arangodb.springframework.annotation.Document;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michele Rastelli
+ */
+public class ShardedCollectionRepositoryTest extends AbstractArangoTest {
+
+    @Autowired
+    ShardedRepository shardedRepository;
+
+    @Test
+    public void save() {
+        ShardedUser d1 = shardedRepository.save(new ShardedUser(null, "name1", "country1"));
+        d1.name = "name2";
+        ShardedUser d2 = shardedRepository.save(d1);
+        assertThat(d2.key).isEqualTo(d1.key);
+        assertThat(d2.country).isEqualTo("country1");
+        assertThat(d2.name).isEqualTo("name2");
+
+        ShardedUser d3 = shardedRepository.save(new ShardedUser(d1.key, "name3", "country1"));
+        assertThat(d3.key).isEqualTo(d1.key);
+        assertThat(d3.country).isEqualTo("country1");
+        assertThat(d3.name).isEqualTo("name3");
+    }
+}
+
+@Document(shardKeys = "country", numberOfShards = 10)
+class ShardedUser {
+    @Id
+    String key;
+    String name;
+    String country;
+
+    public ShardedUser(String key, String name, String country) {
+        this.key = key;
+        this.name = name;
+        this.country = country;
+    }
+
+}
+
+interface ShardedRepository extends ArangoRepository<ShardedUser, String> {
+}


### PR DESCRIPTION
Workaround to repsert limitations on collections sharded by fields other than `_key` (https://github.com/arangodb/docs/pull/509).

Fixes #185