### PR TITLE
Imported query repository

### DIFF
--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -37,7 +37,7 @@ import com.arangodb.springframework.testdata.CustomerNameProjection;
  * @author Mark Vollmary
  * @author Christian Lechner
  */
-public interface CustomerRepository extends ArangoRepository<Customer, String> {
+public interface CustomerRepository extends ArangoRepository<Customer, String>, ImportedQueryRepository{
 
 	@Query("FOR c IN customer FILTER c._key == @id RETURN c")
 	Map<String, Object> findOneByIdAqlWithNamedParameter(@Param("id") String idString, AqlQueryOptions options);

--- a/src/test/java/com/arangodb/springframework/repository/ImportedQueryRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/ImportedQueryRepository.java
@@ -1,0 +1,17 @@
+package com.arangodb.springframework.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.Param;
+
+import com.arangodb.springframework.annotation.Query;
+import com.arangodb.springframework.testdata.Customer;
+
+@NoRepositoryBean
+public interface ImportedQueryRepository {
+
+	@Query("FOR c in #collection FILTER c.surname == @param RETURN c")
+	List<Customer> importedQuery(@Param("param") String param);
+
+}

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -151,6 +151,18 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		assertTrue(equals(retrieved, toBeRetrieved, cmp, eq, false));
 
 	}
+	
+
+	@Test
+	public void findManyBySurnameOnImportedQueryTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		toBeRetrieved.add(new Customer("James", "Smith", 35));
+		toBeRetrieved.add(new Customer("Matt", "Smith", 34));
+		repository.saveAll(toBeRetrieved);
+		final List<Customer> retrieved = repository.importedQuery("Smith");
+		assertTrue(equals(retrieved, toBeRetrieved, cmp, eq, false));
+
+	}
 
 	@Test
 	public void queryCount() {


### PR DESCRIPTION
Hello, this PR is just a unit test to guarantee the functioning of a repository by importing another non-repository interface.
This technique is used to be able to have the same customized query being executed in multiple repositories.