### PR TITLE
remove PostConstruct

### DIFF
--- a/src/test/java/com/arangodb/springframework/AbstractArangoTest.java
+++ b/src/test/java/com/arangodb/springframework/AbstractArangoTest.java
@@ -20,7 +20,6 @@
 
 package com.arangodb.springframework;
 
-import com.arangodb.springframework.core.ArangoOperations;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -28,13 +27,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import javax.annotation.PostConstruct;
+import com.arangodb.springframework.core.ArangoOperations;
 
 /**
  * @author Mark Vollmary
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {ArangoTestConfiguration.class})
+@ContextConfiguration(classes = { ArangoTestConfiguration.class })
 public abstract class AbstractArangoTest {
 
 	private static volatile ArangoOperations staticTemplate;
@@ -53,17 +52,12 @@ public abstract class AbstractArangoTest {
 		for (final Class<?> collection : collections) {
 			template.collection(collection).truncate();
 		}
+		AbstractArangoTest.staticTemplate = template;
 	}
 
 	@AfterClass
 	public static void afterClass() {
 		staticTemplate.dropDatabase();
-	}
-
-
-	@PostConstruct
-	private void postConstruct() {
-		staticTemplate = template;
 	}
 
 }


### PR DESCRIPTION
Hello, how are you?
The PostConstruct annotation is an element of the spring stereotype.
I believe it is not in the right place.
I modified the way it is done, but the end result is the same.
I did this, because I was having trouble running the unit test locally.
Please accept my improvement.