### PR TITLE
fix npe when deactivating type mapping

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoTypeMapper.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoTypeMapper.java
@@ -180,6 +180,9 @@ public class DefaultArangoTypeMapper implements ArangoTypeMapper {
 			}
 
 			if (source.isObject()) {
+				if (this.typeKey == null) {
+					return Alias.NONE;
+				}
 				final VPackSlice typeKey = source.get(this.typeKey);
 				return Alias.ofNullable(typeKey.isString() ? typeKey.getAsString() : null);
 			}


### PR DESCRIPTION
link to [this issue](https://github.com/arangodb/spring-data/issues/210)

When deactivating type mapping, a NullPointerException occurred when reading from arangodb. This commit fixes it