### PR TITLE
fix collecting collection names for with statement

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -20,6 +20,7 @@
 
 package com.arangodb.springframework.repository.query.derived;
 
+import com.arangodb.springframework.annotation.Document;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -584,7 +585,7 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 		}).map(type -> {
 			return context.getPersistentEntity(type);
 		}).filter(entity -> {
-			return entity != null;
+			return entity != null && entity.isAnnotationPresent(Document.class);
 		}).map(entity -> {
 			return AqlUtils.buildCollectionName(entity.getCollection());
 		}).forEach(withCollections::add);


### PR DESCRIPTION
The problem is, that sub-objects of the collection entity are identified as collections as well.
Example:

```java
@Document("company")
public class Company {
  @Id
  @JsonSerialize(using = UUIDSerializer.class)
  @JsonDeserialize(using = UUIDDeserializer.class)
  private UUID id;
  private Name name;
}

public class Name {
  private String value;
}
```

```java
public interface ICompanyRepository extends ArangoRepository<Company, UUID> {
  Collection<Company> findByNameValueStartingWithIgnoreCase(String searchString);
}
```

wrong generated query:
```
WITH name FOR e IN company FILTER LOWER(e.name.value) LIKE @0  RETURN e
```