### PR TITLE
implemented SPEL expressions support in StringBasedArangoQuery

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+- Added SPEL support to custom AQL query on repository methods (#221)
+
 ## [3.5.0] - 2021-04-23
 
 - added annotations to ttl indexes (`@TtlIndex` and `@TtlIndexed`)

--- a/src/main/java/com/arangodb/springframework/annotation/SpelParam.java
+++ b/src/main/java/com/arangodb/springframework/annotation/SpelParam.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
 
 /**
  * Annotation to mark a method parameter of a repository method annotated with {@code @Query} to be used as SPEL's
- * variable in the query expression.
+ * variable in the query expression. The expression prefix is "#{" and the expression suffix is "}".
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/arangodb/springframework/annotation/SpelParam.java
+++ b/src/main/java/com/arangodb/springframework/annotation/SpelParam.java
@@ -1,0 +1,34 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2017 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.springframework.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to mark a method parameter of a repository method annotated with {@code @Query} to be used as SPEL's
+ * variable in the query expression.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SpelParam {
+    String value();
+}

--- a/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactoryBean.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactoryBean.java
@@ -20,7 +20,10 @@
 
 package com.arangodb.springframework.repository;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -32,9 +35,10 @@ import com.arangodb.springframework.core.ArangoOperations;
  * Created by F625633 on 07/07/2017.
  */
 public class ArangoRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
-		extends RepositoryFactoryBeanSupport<T, S, ID> {
+		extends RepositoryFactoryBeanSupport<T, S, ID>  implements ApplicationContextAware {
 
 	private ArangoOperations arangoOperations;
+	private ApplicationContext applicationContext;
 
 	@Autowired
 	public ArangoRepositoryFactoryBean(final Class<? extends T> repositoryInterface) {
@@ -49,6 +53,11 @@ public class ArangoRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 	@Override
 	protected RepositoryFactorySupport createRepositoryFactory() {
 		Assert.notNull(arangoOperations, "arangoOperations not configured");
-		return new ArangoRepositoryFactory(arangoOperations);
+		return new ArangoRepositoryFactory(arangoOperations, applicationContext);
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
 	}
 }

--- a/src/main/java/com/arangodb/springframework/repository/query/ArangoParameterAccessor.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/ArangoParameterAccessor.java
@@ -38,4 +38,6 @@ public interface ArangoParameterAccessor extends ParameterAccessor {
 
 	Map<String, Object> getBindVars();
 
+	Map<String, Object> getSpelVars();
+
 }

--- a/src/main/java/com/arangodb/springframework/repository/query/ArangoParameters.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/ArangoParameters.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import com.arangodb.springframework.annotation.SpelParam;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
@@ -40,7 +41,7 @@ import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.annotation.BindVars;
 
 /**
- * 
+ *
  * @author Audrius Malele
  * @author Mark McCormick
  * @author Mark Vollmary
@@ -148,7 +149,7 @@ public class ArangoParameters extends Parameters<ArangoParameters, ArangoParamet
 
 		@Override
 		public boolean isSpecialParameter() {
-			return super.isSpecialParameter() || isQueryOptions() || isBindVars();
+			return super.isSpecialParameter() || isQueryOptions() || isBindVars() || isSpelParam();
 		}
 
 		public boolean isQueryOptions() {
@@ -158,6 +159,18 @@ public class ArangoParameters extends Parameters<ArangoParameters, ArangoParamet
 		public boolean isBindVars() {
 			return parameter.hasParameterAnnotation(BindVars.class);
 		}
+
+		public boolean isSpelParam() {
+			return parameter.hasParameterAnnotation(SpelParam.class);
+		}
+
+        @Override
+        public Optional<String> getName() {
+            if (isSpelParam())
+                return Optional.of(parameter.getParameterAnnotation(SpelParam.class).value());
+            else
+                return super.getName();
+        }
 
 		@Override
 		public String getPlaceholder() {

--- a/src/main/java/com/arangodb/springframework/repository/query/ArangoParametersParameterAccessor.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/ArangoParametersParameterAccessor.java
@@ -21,6 +21,7 @@
 package com.arangodb.springframework.repository.query;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 
@@ -29,35 +30,42 @@ import com.arangodb.model.AqlQueryOptions;
 /**
  * This class provides access to parameters of a user-defined method. It wraps ParametersParameterAccessor which catches
  * special parameters Sort and Pageable, and catches Arango-specific parameters e.g. AqlQueryOptions.
- * 
+ *
  * @author Audrius Malele
  * @author Mark Vollmary
  * @author Christian Lechner
  */
 public class ArangoParametersParameterAccessor extends ParametersParameterAccessor implements ArangoParameterAccessor {
 
-	private final ArangoParameters parameters;
+    private final ArangoParameters parameters;
 
-	public ArangoParametersParameterAccessor(ArangoQueryMethod method, Object[] values) {
-		super(method.getParameters(), values);
-		this.parameters = method.getParameters();
-	}
+    public ArangoParametersParameterAccessor(ArangoQueryMethod method, Object[] values) {
+        super(method.getParameters(), values);
+        this.parameters = method.getParameters();
+    }
 
-	@Override
-	public ArangoParameters getParameters() {
-		return parameters;
-	}
+    @Override
+    public ArangoParameters getParameters() {
+        return parameters;
+    }
 
-	@Override
-	public AqlQueryOptions getQueryOptions() {
-		final int optionsIndex = parameters.getQueryOptionsIndex();
-		return optionsIndex == -1 ? null : getValue(optionsIndex);
-	}
+    @Override
+    public AqlQueryOptions getQueryOptions() {
+        final int optionsIndex = parameters.getQueryOptionsIndex();
+        return optionsIndex == -1 ? null : getValue(optionsIndex);
+    }
 
-	@Override
-	public Map<String, Object> getBindVars() {
-		final int bindVarsIndex = parameters.getBindVarsIndex();
-		return bindVarsIndex == -1 ? null : getValue(bindVarsIndex);
-	}
+    @Override
+    public Map<String, Object> getBindVars() {
+        final int bindVarsIndex = parameters.getBindVarsIndex();
+        return bindVarsIndex == -1 ? null : getValue(bindVarsIndex);
+    }
+
+    @Override
+    public Map<String, Object> getSpelVars() {
+        return parameters.get()
+                .filter(ArangoParameters.ArangoParameter::isSpelParam)
+                .collect(Collectors.toMap(it -> it.getName().get(), it -> getValue(it.getIndex())));
+    }
 
 }

--- a/src/main/java/com/arangodb/springframework/repository/query/StringBasedArangoQuery.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/StringBasedArangoQuery.java
@@ -41,11 +41,12 @@ import com.arangodb.springframework.core.util.AqlUtils;
 import com.arangodb.springframework.repository.query.ArangoParameters.ArangoParameter;
 
 /**
- * 
+ *
  * @author Audrius Malele
  * @author Mark McCormick
  * @author Mark Vollmary
  * @author Christian Lechner
+ * @author Michele Rastelli
  */
 public class StringBasedArangoQuery extends AbstractArangoQuery {
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
@@ -64,6 +65,7 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 
 	private final StandardEvaluationContext context;
 	private final String query;
+	private	final String collectionName;
 	private final Expression queryExpression;
 	private final Set<String> queryBindParams;
 
@@ -78,6 +80,7 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 		Assert.notNull(query, "Query must not be null!");
 
 		this.query = query;
+		collectionName = AqlUtils.buildCollectionName(operations.collection(domainClass).name());
 
 		assertSinglePageablePlaceholder();
 		assertSingleSortPlaceholder();
@@ -89,7 +92,8 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 		context.setRootObject(applicationContext);
 		context.setBeanResolver(new BeanFactoryResolver(applicationContext));
 		context.addPropertyAccessor(new BeanFactoryAccessor());
-	}
+        context.setVariable("collection", collectionName);
+    }
 
 	@Override
 	protected String createQuery(
@@ -119,7 +123,6 @@ public class StringBasedArangoQuery extends AbstractArangoQuery {
 
 		final Matcher collectionMatcher = COLLECTION_PLACEHOLDER_PATTERN.matcher(preparedQuery);
 		if (collectionMatcher.find()) {
-			final String collectionName = AqlUtils.buildCollectionName(operations.collection(domainClass).name());
 			preparedQuery = collectionMatcher.replaceAll(collectionName);
 		}
 

--- a/src/test/java/com/arangodb/springframework/component/FilterGenerator.java
+++ b/src/test/java/com/arangodb/springframework/component/FilterGenerator.java
@@ -1,0 +1,22 @@
+package com.arangodb.springframework.component;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component("filterGenerator")
+public class FilterGenerator {
+
+    public String allEqual(String col, Map<String, Object> kv) {
+        return kv.entrySet().stream()
+                .map(it -> col + "." + it.getKey() + " == " + escape(it.getValue()))
+                .collect(Collectors.joining(" AND "));
+    }
+
+    private Object escape(Object o) {
+        if (o instanceof String) return "\"" + o + "\"";
+        else return o;
+    }
+
+}

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -40,7 +40,7 @@ import com.arangodb.springframework.testdata.CustomerNameProjection;
  */
 public interface CustomerRepository extends ArangoRepository<Customer, String>, ImportedQueryRepository{
 
-	@Query("FOR c IN #collection FILTER #{filterGenerator.allEqual('c', #kv)} RETURN c")
+	@Query("FOR c IN #{#collection} FILTER #{filterGenerator.allEqual('c', #kv)} RETURN c")
 	List<Customer> findByAllEqual(@SpelParam("kv") Map<String, Object> kv);
 
 	@Query("FOR c IN #collection FILTER c._key == @id RETURN c")

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.arangodb.springframework.annotation.SpelParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
@@ -31,7 +32,7 @@ import com.arangodb.springframework.testdata.Customer;
 import com.arangodb.springframework.testdata.CustomerNameProjection;
 
 /**
- * 
+ *
  * @author Audrius Malele
  * @author Mark McCormick
  * @author Mark Vollmary
@@ -39,7 +40,10 @@ import com.arangodb.springframework.testdata.CustomerNameProjection;
  */
 public interface CustomerRepository extends ArangoRepository<Customer, String>, ImportedQueryRepository{
 
-	@Query("FOR c IN customer FILTER c._key == @id RETURN c")
+	@Query("FOR c IN #collection FILTER #{filterGenerator.allEqual('c', #kv)} RETURN c")
+	List<Customer> findByAllEqual(@SpelParam("kv") Map<String, Object> kv);
+
+	@Query("FOR c IN #collection FILTER c._key == @id RETURN c")
 	Map<String, Object> findOneByIdAqlWithNamedParameter(@Param("id") String idString, AqlQueryOptions options);
 
 	@Query("FOR c IN #collection FILTER c.name == @1 AND c._key == @0 RETURN c")

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -14,7 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.arangodb.springframework.component.FilterGenerator;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -44,9 +43,6 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 	@Autowired
 	protected OverriddenCrudMethodsRepository overriddenRepository;
 
-	@Autowired
-	FilterGenerator filterGenerator;
-
     @Test
     public void dynamicFilter() {
         repository.saveAll(customers);
@@ -58,6 +54,10 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		List<Customer> retrieved = repository.findByAllEqual(filters);
 		assertThat(retrieved, hasSize(1));
 		assertEquals(john, retrieved.get(0));
+
+		filters.put("age", 21);
+		retrieved = repository.findByAllEqual(filters);
+		assertThat(retrieved, hasSize(0));
 	}
 
 	@Test

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -1,8 +1,7 @@
 package com.arangodb.springframework.repository.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsIn.isOneOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -15,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.arangodb.springframework.component.FilterGenerator;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -33,7 +33,7 @@ import com.arangodb.springframework.testdata.Customer;
 import com.arangodb.springframework.testdata.CustomerNameProjection;
 
 /**
- * 
+ *
  * @author Audrius Malele
  * @author Mark McCormick
  * @author Mark Vollmary
@@ -43,6 +43,22 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 
 	@Autowired
 	protected OverriddenCrudMethodsRepository overriddenRepository;
+
+	@Autowired
+	FilterGenerator filterGenerator;
+
+    @Test
+    public void dynamicFilter() {
+        repository.saveAll(customers);
+
+		Map<String, Object> filters = new HashMap<>();
+		filters.put("name", "John");
+		filters.put("surname", "Smith");
+		filters.put("age", 20);
+		List<Customer> retrieved = repository.findByAllEqual(filters);
+		assertThat(retrieved, hasSize(1));
+		assertEquals(john, retrieved.get(0));
+	}
 
 	@Test
 	public void findOneByIdAqlWithNamedParameterTest() {
@@ -151,7 +167,7 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		assertTrue(equals(retrieved, toBeRetrieved, cmp, eq, false));
 
 	}
-	
+
 
 	@Test
 	public void findManyBySurnameOnImportedQueryTest() {


### PR DESCRIPTION
This allows to use SPEL expressions in user queries provided in `@Query` annotation, enabling to dynamically customize the query depending on the invocation parameters and/or invoking methods on Spring Beans.

Notes:
- SPEL expressions must be wrapped within `#{}`
- SPEL variables can be set annotating method parameters with `@SpelParam("varName")` and referenced with `#varName` in the expression
- the SPEL variable `#collection` is automatically set
- Spring Beans can be referenced with `@myBean` (factory beans with `&myBean`)

Related doc: https://github.com/arangodb/docs/pull/759

Related Slack discussion:
https://arangodb-community.slack.com/archives/C07NV9NAH/p1627588268058100