### PR TITLE
Support of geoJson types and Spring geo types

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - master
-      - 2.3.x
   push:
     branches:
       - master
-      - 2.3.x
 
 jobs:
   package:
@@ -23,7 +21,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Package
-        run: mvn --no-transfer-progress -DskipTests=true package
+        run: mvn --no-transfer-progress -DskipTests=true -Dgpg.skip=true verify
 
   test:
 
@@ -34,12 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         docker-img:
-          - docker.io/arangodb/arangodb:3.5.6
-          - docker.io/arangodb/arangodb:3.6.7
-          - docker.io/arangodb/arangodb:3.7.2
-          - docker.io/arangodb/enterprise:3.5.6
-          - docker.io/arangodb/enterprise:3.6.7
-          - docker.io/arangodb/enterprise:3.7.2
+          - docker.io/arangodb/arangodb:3.6.15
+          - docker.io/arangodb/arangodb:3.7.14
+          - docker.io/arangodb/arangodb:3.8.1
+          - docker.io/arangodb/enterprise:3.6.15
+          - docker.io/arangodb/enterprise:3.7.14
+          - docker.io/arangodb/enterprise:3.8.1
         topology:
           - single
           - cluster

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,12 @@
 			<version>2.0.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.arangodb</groupId>
 	<artifactId>arangodb-spring-data</artifactId>
-	<version>3.5.0</version>
+	<version>3.6.0-SNAPSHOT</version>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>jar</packaging>
 

--- a/src/main/java/com/arangodb/springframework/core/convert/ArangoCustomConversions.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/ArangoCustomConversions.java
@@ -43,6 +43,7 @@ public class ArangoCustomConversions extends CustomConversions {
 		storeConverters.addAll(TimeStringConverters.getConvertersToRegister());
 		storeConverters.addAll(JodaTimeStringConverters.getConvertersToRegister());
 		storeConverters.addAll(ArangoConverters.getConvertersToRegister());
+		storeConverters.addAll(GeoConverters.getConvertersToRegister());
 
 		STORE_CONVERSIONS = StoreConversions.of(ArangoSimpleTypes.HOLDER,
 			Collections.unmodifiableCollection(storeConverters));

--- a/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
@@ -36,6 +36,7 @@ public class GeoConverters {
                 GeoJsonMultiLineStringToDBDocumentEntityConverter.INSTANCE,
                 PolygonToDBDocumentEntityConverter.INSTANCE,
                 GeoJsonPolygonToDBDocumentEntityConverter.INSTANCE,
+                BoxToDBDocumentEntityConverter.INSTANCE,
 
                 // reading converters
                 DBDocumentEntityToGeoJsonConverter.INSTANCE,
@@ -141,6 +142,26 @@ public class GeoConverters {
             d.put(TYPE, source.getType());
             d.put(COORDS, lineStringsToList(source.getCoordinates()));
             return d;
+        }
+    }
+
+    @WritingConverter
+    enum BoxToDBDocumentEntityConverter implements Converter<Box, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(Box source) {
+            Point a = source.getFirst();
+            Point b = source.getSecond();
+            Polygon p = new Polygon(
+                    new Point(a.getX(), a.getY()),
+                    new Point(a.getX(), b.getY()),
+                    new Point(b.getX(), b.getY()),
+                    new Point(b.getX(), a.getY()),
+                    new Point(a.getX(), a.getY())
+            );
+            return PolygonToDBDocumentEntityConverter.INSTANCE.convert(p);
         }
     }
 

--- a/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
@@ -1,0 +1,107 @@
+package com.arangodb.springframework.core.convert;
+
+import com.arangodb.springframework.core.geo.GeoJson;
+import com.arangodb.springframework.core.geo.GeoJsonPoint;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.geo.*;
+import org.springframework.util.Assert;
+
+import java.util.*;
+import java.util.function.Function;
+
+
+// TODO:
+// - test @GeoIndex and @GeoIndexed on GeoJson fields (geoJson=true)
+// - query derivation with geo and geoJson types
+
+public class GeoConverters {
+
+    private static final Map<String, Function<DBDocumentEntity, GeoJson<?>>> toGeoJsonConverters = new HashMap<>();
+
+    static {
+        toGeoJsonConverters.put("Point", DBDocumentEntityToGeoJsonPointConverter.INSTANCE::convert);
+//        toGeoJsonConverters.put("MultiPoint", DBDocumentEntityToGeoJsonMultiPointConverter.INSTANCE::convert);
+//        toGeoJsonConverters.put("LineString", DBDocumentEntityToGeoJsonLineStringConverter.INSTANCE::convert);
+//        toGeoJsonConverters.put("MultiLineString", DBDocumentEntityToGeoJsonMultiLineStringConverter.INSTANCE::convert);
+//        toGeoJsonConverters.put("Polygon", DBDocumentEntityToGeoJsonPolygonConverter.INSTANCE::convert);
+    }
+
+    public static Collection<Converter<?, ?>> getConvertersToRegister() {
+        return Arrays.asList(
+                PointToDBDocumentEntityConverter.INSTANCE,
+                GeoJsonToDBDocumentEntityConverter.INSTANCE,
+                DBDocumentEntityToGeoJsonConverter.INSTANCE,
+                DBDocumentEntityToPointConverter.INSTANCE,
+                DBDocumentEntityToGeoJsonPointConverter.INSTANCE
+        );
+    }
+
+    private GeoConverters() {
+    }
+
+    @WritingConverter
+    enum PointToDBDocumentEntityConverter implements Converter<Point, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(Point source) {
+            return GeoJsonToDBDocumentEntityConverter.INSTANCE.convert(new GeoJsonPoint(source));
+        }
+    }
+
+    @WritingConverter
+    enum GeoJsonToDBDocumentEntityConverter implements Converter<GeoJson<?>, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(GeoJson<?> source) {
+            DBDocumentEntity d = new DBDocumentEntity();
+            d.put("type", source.getType());
+            d.put("coordinates", source.getCoordinates());
+            return d;
+        }
+    }
+
+    @ReadingConverter
+    enum DBDocumentEntityToGeoJsonConverter implements Converter<DBDocumentEntity, GeoJson<?>> {
+
+        INSTANCE;
+
+        @Override
+        public GeoJson<?> convert(DBDocumentEntity source) {
+            String type = (String) source.get("type");
+            return toGeoJsonConverters.get(type).apply(source);
+        }
+    }
+
+    @ReadingConverter
+    enum DBDocumentEntityToPointConverter implements Converter<DBDocumentEntity, Point> {
+
+        INSTANCE;
+
+        @Override
+        public Point convert(DBDocumentEntity source) {
+            return DBDocumentEntityToGeoJsonPointConverter.INSTANCE.convert(source);
+        }
+    }
+
+    @ReadingConverter
+    enum DBDocumentEntityToGeoJsonPointConverter implements Converter<DBDocumentEntity, GeoJsonPoint> {
+
+        INSTANCE;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public GeoJsonPoint convert(DBDocumentEntity source) {
+            Assert.isTrue("Point".equals(source.get("type")), "source type must be 'Point'");
+            List<Number> coords = (List<Number>) source.get("coordinates");
+            return new GeoJsonPoint(coords.get(0).doubleValue(), coords.get(1).doubleValue());
+        }
+    }
+
+
+}

--- a/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/GeoConverters.java
@@ -1,7 +1,6 @@
 package com.arangodb.springframework.core.convert;
 
-import com.arangodb.springframework.core.geo.GeoJson;
-import com.arangodb.springframework.core.geo.GeoJsonPoint;
+import com.arangodb.springframework.core.geo.*;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
@@ -22,19 +21,28 @@ public class GeoConverters {
 
     static {
         toGeoJsonConverters.put("Point", DBDocumentEntityToGeoJsonPointConverter.INSTANCE::convert);
-//        toGeoJsonConverters.put("MultiPoint", DBDocumentEntityToGeoJsonMultiPointConverter.INSTANCE::convert);
-//        toGeoJsonConverters.put("LineString", DBDocumentEntityToGeoJsonLineStringConverter.INSTANCE::convert);
-//        toGeoJsonConverters.put("MultiLineString", DBDocumentEntityToGeoJsonMultiLineStringConverter.INSTANCE::convert);
+        toGeoJsonConverters.put("MultiPoint", DBDocumentEntityToGeoJsonMultiPointConverter.INSTANCE::convert);
+        toGeoJsonConverters.put("LineString", DBDocumentEntityToGeoJsonLineStringConverter.INSTANCE::convert);
+        toGeoJsonConverters.put("MultiLineString", DBDocumentEntityToGeoJsonMultiLineStringConverter.INSTANCE::convert);
 //        toGeoJsonConverters.put("Polygon", DBDocumentEntityToGeoJsonPolygonConverter.INSTANCE::convert);
     }
 
     public static Collection<Converter<?, ?>> getConvertersToRegister() {
         return Arrays.asList(
+                // writing converters
                 PointToDBDocumentEntityConverter.INSTANCE,
-                GeoJsonToDBDocumentEntityConverter.INSTANCE,
+                GeoJsonPointToDBDocumentEntityConverter.INSTANCE,
+                GeoJsonMultiPointToDBDocumentEntityConverter.INSTANCE,
+                GeoJsonLineStringToDBDocumentEntityConverter.INSTANCE,
+                GeoJsonMultiLineStringToDBDocumentEntityConverter.INSTANCE,
+
+                // reading converters
                 DBDocumentEntityToGeoJsonConverter.INSTANCE,
                 DBDocumentEntityToPointConverter.INSTANCE,
-                DBDocumentEntityToGeoJsonPointConverter.INSTANCE
+                DBDocumentEntityToGeoJsonPointConverter.INSTANCE,
+                DBDocumentEntityToGeoJsonMultiPointConverter.INSTANCE,
+                DBDocumentEntityToGeoJsonLineStringConverter.INSTANCE,
+                DBDocumentEntityToGeoJsonMultiLineStringConverter.INSTANCE
         );
     }
 
@@ -48,20 +56,62 @@ public class GeoConverters {
 
         @Override
         public DBDocumentEntity convert(Point source) {
-            return GeoJsonToDBDocumentEntityConverter.INSTANCE.convert(new GeoJsonPoint(source));
+            return GeoJsonPointToDBDocumentEntityConverter.INSTANCE.convert(new GeoJsonPoint(source));
         }
     }
 
     @WritingConverter
-    enum GeoJsonToDBDocumentEntityConverter implements Converter<GeoJson<?>, DBDocumentEntity> {
+    enum GeoJsonPointToDBDocumentEntityConverter implements Converter<GeoJsonPoint, DBDocumentEntity> {
 
         INSTANCE;
 
         @Override
-        public DBDocumentEntity convert(GeoJson<?> source) {
+        public DBDocumentEntity convert(GeoJsonPoint source) {
             DBDocumentEntity d = new DBDocumentEntity();
             d.put("type", source.getType());
             d.put("coordinates", source.getCoordinates());
+            return d;
+        }
+    }
+
+    @WritingConverter
+    enum GeoJsonMultiPointToDBDocumentEntityConverter implements Converter<GeoJsonMultiPoint, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(GeoJsonMultiPoint source) {
+            DBDocumentEntity d = new DBDocumentEntity();
+            d.put("type", source.getType());
+            d.put("coordinates", pointsToList(source.getCoordinates()));
+            return d;
+        }
+    }
+
+    @WritingConverter
+    enum GeoJsonLineStringToDBDocumentEntityConverter implements Converter<GeoJsonLineString, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(GeoJsonLineString source) {
+            DBDocumentEntity d = new DBDocumentEntity();
+            d.put("type", source.getType());
+            d.put("coordinates", pointsToList(source.getCoordinates()));
+            return d;
+        }
+    }
+
+    @WritingConverter
+    enum GeoJsonMultiLineStringToDBDocumentEntityConverter implements Converter<GeoJsonMultiLineString, DBDocumentEntity> {
+
+        INSTANCE;
+
+        @Override
+        public DBDocumentEntity convert(GeoJsonMultiLineString source) {
+            DBDocumentEntity d = new DBDocumentEntity();
+            d.put("type", source.getType());
+            d.put("coordinates", lineStringsToList(source.getCoordinates()));
             return d;
         }
     }
@@ -98,10 +148,94 @@ public class GeoConverters {
         @SuppressWarnings("unchecked")
         public GeoJsonPoint convert(DBDocumentEntity source) {
             Assert.isTrue("Point".equals(source.get("type")), "source type must be 'Point'");
-            List<Number> coords = (List<Number>) source.get("coordinates");
-            return new GeoJsonPoint(coords.get(0).doubleValue(), coords.get(1).doubleValue());
+            return toPoint((List<Number>) source.get("coordinates"));
         }
     }
 
+    @ReadingConverter
+    enum DBDocumentEntityToGeoJsonMultiPointConverter implements Converter<DBDocumentEntity, GeoJsonMultiPoint> {
+
+        INSTANCE;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public GeoJsonMultiPoint convert(DBDocumentEntity source) {
+            Assert.isTrue("MultiPoint".equals(source.get("type")), "source type must be 'MultiPoint'");
+            Iterable<Iterable<Number>> coords = (Iterable<Iterable<Number>>) source.get("coordinates");
+            return new GeoJsonMultiPoint(toListOfPoint(coords));
+        }
+    }
+
+    @ReadingConverter
+    enum DBDocumentEntityToGeoJsonLineStringConverter implements Converter<DBDocumentEntity, GeoJsonLineString> {
+
+        INSTANCE;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public GeoJsonLineString convert(DBDocumentEntity source) {
+            Assert.isTrue("LineString".equals(source.get("type")), "source type must be 'LineString'");
+            Iterable<Iterable<Number>> coords = (Iterable<Iterable<Number>>) source.get("coordinates");
+            return new GeoJsonLineString(toListOfPoint(coords));
+        }
+    }
+
+    @ReadingConverter
+    enum DBDocumentEntityToGeoJsonMultiLineStringConverter implements Converter<DBDocumentEntity, GeoJsonMultiLineString> {
+
+        INSTANCE;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public GeoJsonMultiLineString convert(DBDocumentEntity source) {
+            Assert.isTrue("MultiLineString".equals(source.get("type")), "source type must be 'MultiLineString'");
+            Iterable<Iterable<Iterable<Number>>> coords = (Iterable<Iterable<Iterable<Number>>>) source.get("coordinates");
+            return new GeoJsonMultiLineString(toListOfLineStrings(coords));
+        }
+    }
+
+
+    private static List<Double> pointToList(Point point) {
+        return Arrays.asList(point.getX(), point.getY());
+    }
+
+    private static List<List<Double>> pointsToList(Iterable<Point> points) {
+        List<List<Double>> l = new ArrayList<>();
+        for (Point p : points) {
+            l.add(pointToList(p));
+        }
+        return l;
+    }
+
+    private static List<List<List<Double>>> lineStringsToList(Iterable<GeoJsonLineString> lineStrings) {
+        List<List<List<Double>>> l = new ArrayList<>();
+        for (GeoJsonLineString ls : lineStrings) {
+            l.add(pointsToList(ls.getCoordinates()));
+        }
+        return l;
+    }
+
+    private static GeoJsonPoint toPoint(Iterable<Number> coords) {
+        Iterator<Number> it = coords.iterator();
+        double x = it.next().doubleValue();
+        double y = it.next().doubleValue();
+        return new GeoJsonPoint(x, y);
+    }
+
+    private static List<Point> toListOfPoint(Iterable<Iterable<Number>> coords) {
+        List<Point> points = new ArrayList<>();
+        for (Iterable<Number> point : coords) {
+            points.add(toPoint(point));
+        }
+        return points;
+    }
+
+    private static List<GeoJsonLineString> toListOfLineStrings(Iterable<Iterable<Iterable<Number>>> coords) {
+        List<GeoJsonLineString> lineStrings = new ArrayList<>();
+        for (Iterable<Iterable<Number>> c : coords) {
+            lineStrings.add(new GeoJsonLineString(toListOfPoint(c)));
+        }
+        return lineStrings;
+    }
 
 }

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJson.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJson.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+/**
+ * Interface definition for structures defined in <a href="https://geojson.org/">GeoJSON</a> format.
+ *
+ * @author Christoph Strobl
+ */
+public interface GeoJson<T extends Iterable<?>> {
+
+	/**
+	 * String value representing the type of the {@link GeoJson} object.
+	 *
+	 * @return will never be {@literal null}.
+	 * @see <a href="https://geojson.org/geojson-spec.html#geojson-objects">https://geojson.org/geojson-spec.html#geojson-objects</a>
+	 */
+	String getType();
+
+	/**
+	 * The value of the coordinates member is always an {@link Iterable}. The structure for the elements within is
+	 * determined by {@link #getType()} of geometry.
+	 *
+	 * @return will never be {@literal null}.
+	 * @see <a href="https://geojson.org/geojson-spec.html#geometry-objects">https://geojson.org/geojson-spec.html#geometry-objects</a>
+	 */
+	T getCoordinates();
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonLineString.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonLineString.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.data.geo.Point;
+
+import java.util.List;
+
+/**
+ * {@link GeoJsonLineString} is defined as list of at least 2 {@link Point}s.
+ *
+ * @author Christoph Strobl
+ * @see <a href="https://geojson.org/geojson-spec.html#linestring">https://geojson.org/geojson-spec.html#linestring</a>
+ */
+public class GeoJsonLineString extends GeoJsonMultiPoint {
+
+	private static final String TYPE = "LineString";
+
+	/**
+	 * Creates a new {@link GeoJsonLineString} for the given {@link Point}s.
+	 *
+	 * @param points must not be {@literal null} and have at least 2 entries.
+	 */
+	public GeoJsonLineString(List<Point> points) {
+		super(points);
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonLineString} for the given {@link Point}s.
+	 *
+	 * @param first must not be {@literal null}
+	 * @param second must not be {@literal null}
+	 * @param others can be {@literal null}
+	 */
+	public GeoJsonLineString(Point first, Point second, Point... others) {
+		super(first, second, others);
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiLineString.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiLineString.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.data.geo.Point;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link GeoJsonMultiLineString} is defined as list of {@link GeoJsonLineString}s.
+ *
+ * @author Christoph Strobl
+ * @see <a href="https://geojson.org/geojson-spec.html#multilinestring">https://geojson.org/geojson-spec.html#multilinestring</a>
+ */
+public class GeoJsonMultiLineString implements GeoJson<Iterable<GeoJsonLineString>> {
+
+	private static final String TYPE = "MultiLineString";
+
+	private List<GeoJsonLineString> coordinates = new ArrayList<GeoJsonLineString>();
+
+	/**
+	 * Creates new {@link GeoJsonMultiLineString} for the given {@link Point}s.
+	 *
+	 * @param lines must not be {@literal null}.
+	 */
+	public GeoJsonMultiLineString(List<Point>... lines) {
+
+		Assert.notEmpty(lines, "Points for MultiLineString must not be null!");
+
+		for (List<Point> line : lines) {
+			this.coordinates.add(new GeoJsonLineString(line));
+		}
+	}
+
+	/**
+	 * Creates new {@link GeoJsonMultiLineString} for the given {@link GeoJsonLineString}s.
+	 *
+	 * @param lines must not be {@literal null}.
+	 */
+	public GeoJsonMultiLineString(List<GeoJsonLineString> lines) {
+
+		Assert.notNull(lines, "Lines for MultiLineString must not be null!");
+
+		this.coordinates.addAll(lines);
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public Iterable<GeoJsonLineString> getCoordinates() {
+		return Collections.unmodifiableList(this.coordinates);
+	}
+
+	@Override
+	public int hashCode() {
+		return ObjectUtils.nullSafeHashCode(this.coordinates);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof GeoJsonMultiLineString)) {
+			return false;
+		}
+
+		return ObjectUtils.nullSafeEquals(this.coordinates, ((GeoJsonMultiLineString) obj).coordinates);
+	}
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiPoint.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiPoint.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.data.geo.Point;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link GeoJsonMultiPoint} is defined as list of {@link Point}s.
+ *
+ * @author Christoph Strobl
+ * @author Ivan Volzhev
+ * @see <a href="https://geojson.org/geojson-spec.html#multipoint">https://geojson.org/geojson-spec.html#multipoint</a>
+ */
+public class GeoJsonMultiPoint implements GeoJson<Iterable<Point>> {
+
+	private static final String TYPE = "MultiPoint";
+
+	private final List<Point> points;
+
+	/**
+	 * Creates a new {@link GeoJsonMultiPoint} for the given {@link Point}.
+	 *
+	 * @param point must not be {@literal null}.
+	 * @since 3.2.5
+	 */
+	public GeoJsonMultiPoint(Point point) {
+
+		Assert.notNull(point, "Point must not be null!");
+
+		this.points = new ArrayList<>();
+		this.points.add(point);
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonMultiPoint} for the given {@link Point}s.
+	 *
+	 * @param points points must not be {@literal null} and not empty
+	 */
+	public GeoJsonMultiPoint(List<Point> points) {
+
+		Assert.notNull(points, "Points must not be null!");
+		Assert.notEmpty(points, "Points must contain at least one point!");
+
+		this.points = new ArrayList<>(points);
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonMultiPoint} for the given {@link Point}s.
+	 *
+	 * @param first must not be {@literal null}.
+	 * @param second must not be {@literal null}.
+	 * @param others must not be {@literal null}.
+	 */
+	public GeoJsonMultiPoint(Point first, Point second, Point... others) {
+
+		Assert.notNull(first, "First point must not be null!");
+		Assert.notNull(second, "Second point must not be null!");
+		Assert.notNull(others, "Additional points must not be null!");
+
+		this.points = new ArrayList<>();
+		this.points.add(first);
+		this.points.add(second);
+		this.points.addAll(Arrays.asList(others));
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public List<Point> getCoordinates() {
+		return Collections.unmodifiableList(this.points);
+	}
+
+	@Override
+	public int hashCode() {
+		return ObjectUtils.nullSafeHashCode(this.points);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof GeoJsonMultiPoint)) {
+			return false;
+		}
+
+		return ObjectUtils.nullSafeEquals(this.points, ((GeoJsonMultiPoint) obj).points);
+	}
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiPolygon.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonMultiPolygon.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link GeoJsonMultiPolygon} is defined as a list of {@link GeoJsonPolygon}s.
+ *
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class GeoJsonMultiPolygon implements GeoJson<Iterable<GeoJsonPolygon>> {
+
+	private static final String TYPE = "MultiPolygon";
+
+	private List<GeoJsonPolygon> coordinates = new ArrayList<GeoJsonPolygon>();
+
+	/**
+	 * Creates a new {@link GeoJsonMultiPolygon} for the given {@link GeoJsonPolygon}s.
+	 *
+	 * @param polygons must not be {@literal null}.
+	 */
+	public GeoJsonMultiPolygon(List<GeoJsonPolygon> polygons) {
+
+		Assert.notNull(polygons, "Polygons for MultiPolygon must not be null!");
+
+		this.coordinates.addAll(polygons);
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public List<GeoJsonPolygon> getCoordinates() {
+		return Collections.unmodifiableList(this.coordinates);
+	}
+
+	@Override
+	public int hashCode() {
+		return ObjectUtils.nullSafeHashCode(this.coordinates);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof GeoJsonMultiPolygon)) {
+			return false;
+		}
+
+		return ObjectUtils.nullSafeEquals(this.coordinates, ((GeoJsonMultiPolygon) obj).coordinates);
+	}
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonPoint.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonPoint.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.data.geo.Point;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@link GeoJson} representation of {@link Point}.
+ *
+ * @author Christoph Strobl
+ * @see <a href="https://geojson.org/geojson-spec.html#point">https://geojson.org/geojson-spec.html#point</a>
+ */
+public class GeoJsonPoint extends Point implements GeoJson<List<Double>> {
+
+	private static final long serialVersionUID = -8026303425147474002L;
+
+	private static final String TYPE = "Point";
+
+	/**
+	 * Creates {@link GeoJsonPoint} for given coordinates.
+	 *
+	 * @param x
+	 * @param y
+	 */
+	public GeoJsonPoint(double x, double y) {
+		super(x, y);
+	}
+
+	/**
+	 * Creates {@link GeoJsonPoint} for given {@link Point}.
+	 *
+	 * @param point must not be {@literal null}.
+	 */
+	public GeoJsonPoint(Point point) {
+		super(point);
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public List<Double> getCoordinates() {
+		return Arrays.asList(Double.valueOf(getX()), Double.valueOf(getY()));
+	}
+}

--- a/src/main/java/com/arangodb/springframework/core/geo/GeoJsonPolygon.java
+++ b/src/main/java/com/arangodb/springframework/core/geo/GeoJsonPolygon.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.springframework.core.geo;
+
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+import org.springframework.util.Assert;
+
+import java.util.*;
+
+/**
+ * {@link GeoJson} representation of {@link Polygon}. Unlike {@link Polygon} the {@link GeoJsonPolygon} requires a
+ * closed border. Which means that the first and last {@link Point} have to have same coordinate pairs.
+ *
+ * @author Christoph Strobl
+ * @author Mark Paluch
+ * @see <a href="https://geojson.org/geojson-spec.html#polygon">https://geojson.org/geojson-spec.html#polygon</a>
+ */
+public class GeoJsonPolygon extends Polygon implements GeoJson<List<GeoJsonLineString>> {
+
+	private static final long serialVersionUID = 3936163018187247185L;
+	private static final String TYPE = "Polygon";
+
+	private List<GeoJsonLineString> coordinates = new ArrayList<GeoJsonLineString>();
+
+	/**
+	 * Creates new {@link GeoJsonPolygon} from the given {@link Point}s.
+	 *
+	 * @param first must not be {@literal null}.
+	 * @param second must not be {@literal null}.
+	 * @param third must not be {@literal null}.
+	 * @param fourth must not be {@literal null}.
+	 * @param others can be empty.
+	 */
+	public GeoJsonPolygon(Point first, Point second, Point third, Point fourth, Point... others) {
+		this(asList(first, second, third, fourth, others));
+	}
+
+	/**
+	 * Creates new {@link GeoJsonPolygon} from the given {@link Point}s.
+	 *
+	 * @param points must not be {@literal null}.
+	 */
+	public GeoJsonPolygon(List<Point> points) {
+
+		super(points);
+		this.coordinates.add(new GeoJsonLineString(points));
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonPolygon} with an inner ring defined be the given {@link Point}s.
+	 *
+	 * @param first must not be {@literal null}.
+	 * @param second must not be {@literal null}.
+	 * @param third must not be {@literal null}.
+	 * @param fourth must not be {@literal null}.
+	 * @param others can be empty.
+	 * @return new {@link GeoJsonPolygon}.
+	 * @since 1.10
+	 */
+	public GeoJsonPolygon withInnerRing(Point first, Point second, Point third, Point fourth, Point... others) {
+		return withInnerRing(asList(first, second, third, fourth, others));
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonPolygon} with an inner ring defined be the given {@link List} of {@link Point}s.
+	 *
+	 * @param points must not be {@literal null}.
+	 * @return new {@link GeoJsonPolygon}.
+	 */
+	public GeoJsonPolygon withInnerRing(List<Point> points) {
+		return withInnerRing(new GeoJsonLineString(points));
+	}
+
+	/**
+	 * Creates a new {@link GeoJsonPolygon} with an inner ring defined be the given {@link GeoJsonLineString}.
+	 *
+	 * @param lineString must not be {@literal null}.
+	 * @return new {@link GeoJsonPolygon}.
+	 * @since 1.10
+	 */
+	public GeoJsonPolygon withInnerRing(GeoJsonLineString lineString) {
+
+		Assert.notNull(lineString, "LineString must not be null!");
+
+		Iterator<GeoJsonLineString> it = this.coordinates.iterator();
+		GeoJsonPolygon polygon = new GeoJsonPolygon(it.next().getCoordinates());
+
+		while (it.hasNext()) {
+			polygon.coordinates.add(it.next());
+		}
+
+		polygon.coordinates.add(lineString);
+		return polygon;
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public List<GeoJsonLineString> getCoordinates() {
+		return Collections.unmodifiableList(this.coordinates);
+	}
+
+	private static List<Point> asList(Point first, Point second, Point third, Point fourth, Point... others) {
+
+		ArrayList<Point> result = new ArrayList<Point>(3 + others.length);
+
+		result.add(first);
+		result.add(second);
+		result.add(third);
+		result.add(fourth);
+		result.addAll(Arrays.asList(others));
+
+		return result;
+	}
+}

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
@@ -80,12 +80,7 @@ public class BindParameterBinding {
 		int index = startIndex;
 		final Ring<?> ring = (Ring<?>) ignoreArgumentCase(value, shouldIgnoreCase);
 		final Point point = ring.getPoint();
-		if(toGeoJson) {
-			uniqueCheck.check(point);
-			bind(index++, point);
-		} else {
-			index = bindPoint(point, uniqueCheck, index);
-		}
+		index = bindPoint(point, uniqueCheck, index, toGeoJson);
 		final Range<?> range = ring.getRange();
 		index = bindRange(range, index);
 		return index;
@@ -117,15 +112,21 @@ public class BindParameterBinding {
 		final Object value,
 		final boolean shouldIgnoreCase,
 		final UniqueCheck uniqueCheck,
-		final int startIndex) {
-		return bindPoint((Point) ignoreArgumentCase(value, shouldIgnoreCase), uniqueCheck, startIndex);
+		final int startIndex,
+		final boolean toGeoJson
+	) {
+		return bindPoint((Point) ignoreArgumentCase(value, shouldIgnoreCase), uniqueCheck, startIndex, toGeoJson);
 	}
 
-	private int bindPoint(final Point point, final UniqueCheck uniqueCheck, final int startIndex) {
+	private int bindPoint(final Point point, final UniqueCheck uniqueCheck, final int startIndex, final boolean toGeoJson) {
 		uniqueCheck.check(point);
 		int index = startIndex;
-		bind(index++, point.getY());
-		bind(index++, point.getX());
+		if(toGeoJson) {
+			bind(index++, point);
+		} else {
+			bind(index++, point.getY());
+			bind(index++, point.getX());
+		}
 		return index;
 	}
 

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
@@ -126,13 +126,19 @@ public class BindParameterBinding {
 		final Object value,
 		final boolean shouldIgnoreCase,
 		final UniqueCheck uniqueCheck,
-		final int startIndex) {
+		final int startIndex,
+		final boolean toGeoJson
+	) {
 		int index = startIndex;
 		final Circle circle = (Circle) ignoreArgumentCase(value, shouldIgnoreCase);
 		final Point center = circle.getCenter();
 		uniqueCheck.check(center);
-		bind(index++, center.getY());
-		bind(index++, center.getX());
+		if (toGeoJson) {
+			bind(index++, center);
+		} else {
+			bind(index++, center.getY());
+			bind(index++, center.getX());
+		}
 		bind(index++, convertDistanceToMeters(circle.getRadius()));
 		return index;
 	}

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/BindParameterBinding.java
@@ -74,11 +74,18 @@ public class BindParameterBinding {
 		final Object value,
 		final boolean shouldIgnoreCase,
 		final UniqueCheck uniqueCheck,
-		final int startIndex) {
+		final int startIndex,
+		final boolean toGeoJson
+	) {
 		int index = startIndex;
 		final Ring<?> ring = (Ring<?>) ignoreArgumentCase(value, shouldIgnoreCase);
 		final Point point = ring.getPoint();
-		index = bindPoint(point, uniqueCheck, index);
+		if(toGeoJson) {
+			uniqueCheck.check(point);
+			bind(index++, point);
+		} else {
+			index = bindPoint(point, uniqueCheck, index);
+		}
 		final Range<?> range = ring.getRange();
 		index = bindRange(range, index);
 		return index;

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/Criteria.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/Criteria.java
@@ -143,6 +143,10 @@ public class Criteria {
 		return new Criteria("IS_IN_POLYGON(@" + index + ", " + property + "[0], " + property + "[1])");
 	}
 
+	public static Criteria geoContains(final int index, final String property) {
+		return new Criteria("GEO_CONTAINS(@" + index + ", " + property + ")");
+	}
+
 	@Override
 	public String toString() {
 		return predicate.toString();

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/Criteria.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/Criteria.java
@@ -134,6 +134,11 @@ public class Criteria {
 				"DISTANCE(" + property + "[0], " + property + "[1], @" + indexLat + ", @" + indexLong + ")");
 	}
 
+	public static Criteria geoDistance(final String property, final int index) {
+		return new Criteria(
+				"GEO_DISTANCE(" + property + ", @" + index + ")");
+	}
+
 	public static Criteria isInPolygon(final int index, final String property) {
 		return new Criteria("IS_IN_POLYGON(@" + index + ", " + property + "[0], " + property + "[1])");
 	}

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -352,8 +352,8 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 		if (!geoFields.isEmpty()) {
 			Assert.isTrue(uniquePoint == null || uniquePoint.equals(point),
 				"Different Points are used - Distance is ambiguous");
-			uniquePoint = point;
 		}
+		uniquePoint = point;
 	}
 
 	/**
@@ -457,10 +457,11 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 			}
 			Assert.isTrue(iterator.hasNext(), "Too few arguments passed");
 			final Object nearValue = iterator.next();
-			final Class<? extends Object> nearClazz = nearValue.getClass();
-			if (nearClazz != Point.class) {
+			if (nearValue instanceof Point) {
+				checkUniquePoint((Point) nearValue);
+			} else {
 				bindingCounter = binding.bind(nearValue, shouldIgnoreCase(part), null, point -> checkUniquePoint(point),
-					bindingCounter);
+						bindingCounter);
 			}
 			criteria = null;
 			break;

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -151,7 +151,7 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 			String distanceSortKey = " SORT ";
 			if (isGeoJsonType) {
 				distanceSortKey += Criteria
-						.geoDistance(uniqueLocation, bind(uniquePoint)).getPredicate();
+						.geoDistance(uniqueLocation, bind(getUniqueGeoJsonPoint())).getPredicate();
 			} else {
 				distanceSortKey += Criteria
 						.distance(uniqueLocation, bind(getUniquePoint()[0]), bind(getUniquePoint()[1])).getPredicate();
@@ -194,6 +194,13 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 			return new double[2];
 		}
 		return new double[] { uniquePoint.getY(), uniquePoint.getX() };
+	}
+
+	public Point getUniqueGeoJsonPoint() {
+		if (uniquePoint == null) {
+			return new Point(0,0);
+		}
+		return uniquePoint;
 	}
 
 	private String ignorePropertyCase(final Part part) {
@@ -510,10 +517,14 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 							.and(Criteria.lte(ignorePropertyCase(part, property) + "[1]", index + 3));
 					bindBox(part, value);
 					break;
-				} else if (clazz == Polygon.class) {
-					criteria = Criteria.isInPolygon(bindPolygon(part, value), ignorePropertyCase(part, property));
-					break;
-				} else {
+                } else if (clazz == Polygon.class) {
+                    if (isGeoJsonType) {
+						criteria = Criteria.geoContains(bind(part, value, null), ignorePropertyCase(part, property));
+                    } else {
+                        criteria = Criteria.isInPolygon(bindPolygon(part, value), ignorePropertyCase(part, property));
+                    }
+                    break;
+                } else {
 					if (clazz == Circle.class) {
 						bindCircle(part, value);
 						break;

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -544,7 +544,7 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
                     break;
                 } else {
 					if (clazz == Circle.class) {
-						bindCircle(part, value);
+						bindCircle(part, value, isGeoJsonType);
 						break;
 					} else if (clazz == Point.class) {
 						if(isGeoJsonType) {
@@ -559,8 +559,13 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 				}
 			}
 			if (criteria == null) {
-				criteria = Criteria.lte(
-					Criteria.distance(ignorePropertyCase(part, property), index, index + 1).getPredicate(), index + 2);
+				if(isGeoJsonType) {
+					criteria = Criteria.lte(
+							Criteria.geoDistance(ignorePropertyCase(part, property), index).getPredicate(), index + 1);
+				} else {
+					criteria = Criteria.lte(
+							Criteria.distance(ignorePropertyCase(part, property), index, index + 1).getPredicate(), index + 2);
+				}
 			}
 			break;
 		default:
@@ -599,9 +604,9 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 			bindingCounter);
 	}
 
-	private void bindCircle(final Part part, final Object value) {
+	private void bindCircle(final Part part, final Object value, final boolean toGeoJson) {
 		bindingCounter = binding.bindCircle(value, shouldIgnoreCase(part), point -> checkUniquePoint(point),
-			bindingCounter);
+			bindingCounter, toGeoJson);
 	}
 
 	private void bindRange(final Part part, final Object value) {

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -521,7 +521,7 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 					if (clazz == Range.class) {
 						bindRange(part, value);
 					} else {
-						bindRing(part, value);
+						bindRing(part, value, isGeoJsonType);
 					}
 					break;
 				} else if (clazz == Box.class) {
@@ -613,9 +613,9 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 		bindingCounter = binding.bindRange(value, shouldIgnoreCase(part), bindingCounter);
 	}
 
-	private void bindRing(final Part part, final Object value) {
+	private void bindRing(final Part part, final Object value, final boolean toGeoJson) {
 		bindingCounter = binding.bindRing(value, shouldIgnoreCase(part), point -> checkUniquePoint(point),
-			bindingCounter);
+			bindingCounter, toGeoJson);
 	}
 
 	private void bindBox(final Part part, final Object value) {

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -183,9 +183,14 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 			if (this.geoFields.isEmpty()) {
 				query.append("e");
 			} else {
-				query.append(format("MERGE(e, { '_distance': %s })",
-					Criteria.distance(uniqueLocation, bind(getUniquePoint()[0]), bind(getUniquePoint()[1]))
-							.getPredicate()));
+				if (hasGeoJsonType) {
+					query.append(format("MERGE(e, { '_distance': %s })",
+							Criteria.geoDistance(uniqueLocation, bind(getUniqueGeoJsonPoint())).getPredicate()));
+				} else {
+					query.append(format("MERGE(e, { '_distance': %s })",
+							Criteria.distance(uniqueLocation, bind(getUniquePoint()[0]), bind(getUniquePoint()[1]))
+									.getPredicate()));
+				}
 			}
 		}
 		return query.toString();

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -552,12 +552,7 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 						bindCircle(part, value, isGeoJsonType);
 						break;
 					} else if (clazz == Point.class) {
-						if(isGeoJsonType) {
-							checkUniquePoint((Point) value);
-							bind(part, value, null);
-						} else {
-							bindPoint(part, value);
-						}
+						bindPoint(part, value, isGeoJsonType);
 					} else {
 						bind(part, value, null);
 					}
@@ -604,9 +599,9 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 		return index;
 	}
 
-	private void bindPoint(final Part part, final Object value) {
+	private void bindPoint(final Part part, final Object value, final boolean toGeoJson) {
 		bindingCounter = binding.bindPoint(value, shouldIgnoreCase(part), point -> checkUniquePoint(point),
-			bindingCounter);
+			bindingCounter, toGeoJson);
 	}
 
 	private void bindCircle(final Part part, final Object value, final boolean toGeoJson) {

--- a/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
+++ b/src/main/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreator.java
@@ -511,11 +511,15 @@ public class DerivedQueryCreator extends AbstractQueryCreator<String, Criteria> 
 					}
 					break;
 				} else if (clazz == Box.class) {
-					criteria = Criteria.lte(index, ignorePropertyCase(part, property) + "[0]")
-							.and(Criteria.lte(ignorePropertyCase(part, property) + "[0]", index + 1))
-							.and(Criteria.lte(index + 2, ignorePropertyCase(part, property) + "[1]"))
-							.and(Criteria.lte(ignorePropertyCase(part, property) + "[1]", index + 3));
-					bindBox(part, value);
+					if (isGeoJsonType) {
+						criteria = Criteria.geoContains(bind(part, value, null), ignorePropertyCase(part, property));
+					} else {
+						criteria = Criteria.lte(index, ignorePropertyCase(part, property) + "[0]")
+								.and(Criteria.lte(ignorePropertyCase(part, property) + "[0]", index + 1))
+								.and(Criteria.lte(index + 2, ignorePropertyCase(part, property) + "[1]"))
+								.and(Criteria.lte(ignorePropertyCase(part, property) + "[1]", index + 3));
+						bindBox(part, value);
+					}
 					break;
                 } else if (clazz == Polygon.class) {
                     if (isGeoJsonType) {

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -169,9 +169,8 @@ public class GeneralMappingTest extends AbstractArangoTest {
         private GeoJsonMultiPoint geoJsonMultiPoint;
         private GeoJsonLineString geoJsonLineString;
         private GeoJsonMultiLineString geoJsonMultiLineString;
-//
-//        private Polygon polygon;
-//        private GeoJsonPolygon geoJsonPolygon;
+        private Polygon polygon;
+        private GeoJsonPolygon geoJsonPolygon;
 
     }
 
@@ -201,12 +200,22 @@ public class GeneralMappingTest extends AbstractArangoTest {
                         new Point(7.7, 8.8)
                 )
         );
+        entity.polygon = new Polygon(Arrays.asList(
+                new Point(1.1, 1.2),
+                new Point(1.3, 1.4),
+                new Point(1.5, 1.6)
+        ));
+        entity.geoJsonPolygon = new GeoJsonPolygon(Arrays.asList(
+                new Point(1.1, 1.2),
+                new Point(1.3, 1.4),
+                new Point(1.5, 1.6)
+        )).withInnerRing(Arrays.asList(
+                new Point(0.1, 0.2),
+                new Point(0.3, 0.4),
+                new Point(0.5, 0.6)
+        ));
 
         VPackSlice written = converter.write(entity);
-
-//        DBDocumentEntity dbe = converter.read(DBDocumentEntity.class, written);
-        // TODO: assert dbe is valid geoJson
-
         GeoTestEntity read = converter.read(GeoTestEntity.class, written);
         assertThat(read.geoJson, is(entity.geoJson));
         assertThat(read.point, is(entity.point));
@@ -214,6 +223,8 @@ public class GeneralMappingTest extends AbstractArangoTest {
         assertThat(read.geoJsonMultiPoint, is(entity.geoJsonMultiPoint));
         assertThat(read.geoJsonLineString, is(entity.geoJsonLineString));
         assertThat(read.geoJsonMultiLineString, is(entity.geoJsonMultiLineString));
+        assertThat(read.polygon, is(entity.polygon));
+        assertThat(read.geoJsonPolygon, is(entity.geoJsonPolygon));
     }
 
     public static class JodaTestEntity extends BasicTestEntity {

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -38,9 +38,13 @@ import com.arangodb.springframework.testdata.Movie;
 import com.arangodb.springframework.testdata.Person;
 import com.arangodb.springframework.testdata.Role;
 import com.arangodb.util.MapBuilder;
+import com.arangodb.velocypack.VPackParser;
 import com.arangodb.velocypack.VPackSlice;
 import org.joda.time.DateTimeZone;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.*;
 import org.springframework.data.geo.Point;
@@ -164,8 +168,6 @@ public class GeneralMappingTest extends AbstractArangoTest {
         private GeoJson<?> geoJson;
         private Point point;
         private GeoJsonPoint geoJsonPoint;
-
-        // TODO:
         private GeoJsonMultiPoint geoJsonMultiPoint;
         private GeoJsonLineString geoJsonLineString;
         private GeoJsonMultiLineString geoJsonMultiLineString;
@@ -175,7 +177,7 @@ public class GeneralMappingTest extends AbstractArangoTest {
     }
 
     @Test
-    public void geoMapping() {
+    public void geoMapping() throws JSONException {
         ArangoConverter converter = template.getConverter();
 
         GeoTestEntity entity = new GeoTestEntity();
@@ -216,15 +218,57 @@ public class GeneralMappingTest extends AbstractArangoTest {
         ));
 
         VPackSlice written = converter.write(entity);
+        JSONObject json = new JSONObject(new VPackParser.Builder().build().toJson(written));
+
         GeoTestEntity read = converter.read(GeoTestEntity.class, written);
         assertThat(read.geoJson, is(entity.geoJson));
+        JSONAssert.assertEquals(
+                "{ type: Point, coordinates: [1.1, 2.2] }",
+                json.getJSONObject("geoJson"),
+                false);
         assertThat(read.point, is(entity.point));
+        JSONAssert.assertEquals(
+                "{ type: Point, coordinates: [1.1, 2.2] }",
+                json.getJSONObject("point"),
+                false);
         assertThat(read.geoJsonPoint, is(entity.geoJsonPoint));
+        JSONAssert.assertEquals(
+                "{ type: Point, coordinates: [1.1, 2.2] }",
+                json.getJSONObject("geoJsonPoint"),
+                false);
         assertThat(read.geoJsonMultiPoint, is(entity.geoJsonMultiPoint));
+        JSONAssert.assertEquals(
+                "{ type: MultiPoint, coordinates: [[1.1, 2.2], [3.3, 4.4]] }",
+                json.getJSONObject("geoJsonMultiPoint"),
+                false);
         assertThat(read.geoJsonLineString, is(entity.geoJsonLineString));
+        JSONAssert.assertEquals(
+                "{ type: LineString, coordinates: [[1.1, 2.2], [3.3, 4.4]] }",
+                json.getJSONObject("geoJsonLineString"),
+                false);
         assertThat(read.geoJsonMultiLineString, is(entity.geoJsonMultiLineString));
+        JSONAssert.assertEquals(
+                "{ type: MultiLineString, coordinates: [" +
+                        "[[1.1, 2.2], [3.3, 4.4]], " +
+                        "[[5.5, 6.6], [7.7, 8.8]]" +
+                        "] }",
+                json.getJSONObject("geoJsonMultiLineString"),
+                false);
         assertThat(read.polygon, is(entity.polygon));
+        JSONAssert.assertEquals(
+                "{ type: Polygon, coordinates: [" +
+                        "[[1.1, 1.2], [1.3, 1.4], [1.5, 1.6]]" +
+                        "] }",
+                json.getJSONObject("polygon"),
+                false);
         assertThat(read.geoJsonPolygon, is(entity.geoJsonPolygon));
+        JSONAssert.assertEquals(
+                "{ type: Polygon, coordinates: [" +
+                        "[[1.1, 1.2], [1.3, 1.4], [1.5, 1.6]], " +
+                        "[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]" +
+                        "] }",
+                json.getJSONObject("geoJsonPolygon"),
+                false);
     }
 
     public static class JodaTestEntity extends BasicTestEntity {

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -31,8 +31,7 @@ import com.arangodb.springframework.annotation.Field;
 import com.arangodb.springframework.annotation.Ref;
 import com.arangodb.springframework.core.ArangoOperations.UpsertStrategy;
 import com.arangodb.springframework.core.convert.ArangoConverter;
-import com.arangodb.springframework.core.geo.GeoJson;
-import com.arangodb.springframework.core.geo.GeoJsonPoint;
+import com.arangodb.springframework.core.geo.*;
 import com.arangodb.springframework.core.mapping.testdata.BasicTestEntity;
 import com.arangodb.springframework.testdata.Actor;
 import com.arangodb.springframework.testdata.Movie;
@@ -45,6 +44,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.*;
 import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -161,9 +161,18 @@ public class GeneralMappingTest extends AbstractArangoTest {
     }
 
     public static class GeoTestEntity extends BasicTestEntity {
+        private GeoJson<?> geoJson;
         private Point point;
         private GeoJsonPoint geoJsonPoint;
-        private GeoJson<?> geoJson;
+
+        // TODO:
+        private GeoJsonMultiPoint geoJsonMultiPoint;
+        private GeoJsonLineString geoJsonLineString;
+        private GeoJsonMultiLineString geoJsonMultiLineString;
+//
+//        private Polygon polygon;
+//        private GeoJsonPolygon geoJsonPolygon;
+
     }
 
     @Test
@@ -171,18 +180,40 @@ public class GeneralMappingTest extends AbstractArangoTest {
         ArangoConverter converter = template.getConverter();
 
         GeoTestEntity entity = new GeoTestEntity();
+        entity.geoJson = new GeoJsonPoint(1.1, 2.2);
         entity.point = new Point(1.1, 2.2);
-        entity.geoJsonPoint = new GeoJsonPoint(3.3, 4.4);
-        entity.geoJson = new GeoJsonPoint(5.5, 6.6);
+        entity.geoJsonPoint = new GeoJsonPoint(1.1, 2.2);
+        entity.geoJsonMultiPoint = new GeoJsonMultiPoint(
+                new Point(1.1, 2.2),
+                new Point(3.3, 4.4)
+        );
+        entity.geoJsonLineString = new GeoJsonLineString(
+                new Point(1.1, 2.2),
+                new Point(3.3, 4.4)
+        );
+        entity.geoJsonMultiLineString = new GeoJsonMultiLineString(
+                Arrays.asList(
+                        new Point(1.1, 2.2),
+                        new Point(3.3, 4.4)
+                ),
+                Arrays.asList(
+                        new Point(5.5, 6.6),
+                        new Point(7.7, 8.8)
+                )
+        );
+
         VPackSlice written = converter.write(entity);
 
 //        DBDocumentEntity dbe = converter.read(DBDocumentEntity.class, written);
         // TODO: assert dbe is valid geoJson
 
         GeoTestEntity read = converter.read(GeoTestEntity.class, written);
+        assertThat(read.geoJson, is(entity.geoJson));
         assertThat(read.point, is(entity.point));
         assertThat(read.geoJsonPoint, is(entity.geoJsonPoint));
-        assertThat(read.geoJson, is(entity.geoJson));
+        assertThat(read.geoJsonMultiPoint, is(entity.geoJsonMultiPoint));
+        assertThat(read.geoJsonLineString, is(entity.geoJsonLineString));
+        assertThat(read.geoJsonMultiLineString, is(entity.geoJsonMultiLineString));
     }
 
     public static class JodaTestEntity extends BasicTestEntity {

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -30,6 +30,9 @@ import com.arangodb.springframework.annotation.Document;
 import com.arangodb.springframework.annotation.Field;
 import com.arangodb.springframework.annotation.Ref;
 import com.arangodb.springframework.core.ArangoOperations.UpsertStrategy;
+import com.arangodb.springframework.core.convert.ArangoConverter;
+import com.arangodb.springframework.core.geo.GeoJson;
+import com.arangodb.springframework.core.geo.GeoJsonPoint;
 import com.arangodb.springframework.core.mapping.testdata.BasicTestEntity;
 import com.arangodb.springframework.testdata.Actor;
 import com.arangodb.springframework.testdata.Movie;
@@ -41,6 +44,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.*;
+import org.springframework.data.geo.Point;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -55,592 +59,616 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Mark Vollmary
  * @author Christian Lechner
- *
  */
 public class GeneralMappingTest extends AbstractArangoTest {
 
-	@Test
-	public void idKeyRev() {
-		final DocumentEntity ref = template.insert(new BasicTestEntity());
-		final BasicTestEntity entity = template.find(ref.getId(), BasicTestEntity.class).get();
-		assertThat(entity, is(notNullValue()));
-		assertThat(entity.getId(), is(ref.getKey()));
-		assertThat(entity.getRev(), is(ref.getRev()));
-	}
-
-	public static class OnlyIdTestEntity {
-		@Id
-		private String id;
-	}
-
-	@Test
-	public void supplementKey() {
-		final OnlyIdTestEntity value = new OnlyIdTestEntity();
-		template.insert(value);
-		final List<BasicTestEntity> result = template.query("RETURN @doc", new MapBuilder().put("doc", value).get(),
-			new AqlQueryOptions(), BasicTestEntity.class).asListRemaining();
-		assertThat(result.size(), is(1));
-		assertThat(result.get(0).getId(), is(value.id));
-		assertThat(result.get(0).getRev(), is(nullValue()));
-	}
-
-	public static class FieldNameTestEntity extends BasicTestEntity {
-		@Field("alt-test")
-		private String test;
-	}
-
-	@Test
-	public void fieldNameAnnotation() {
-		final FieldNameTestEntity entity = new FieldNameTestEntity();
-		entity.test = "1234";
-		final DocumentEntity res = template.insert(entity);
-		final VPackSlice slice = template.driver().db(ArangoTestConfiguration.DB).getDocument(res.getId(),
-			VPackSlice.class);
-		assertThat(slice, is(notNullValue()));
-		assertThat(slice.get("alt-test").isString(), is(true));
-		assertThat(slice.get("alt-test").getAsString(), is(entity.test));
-	}
-
-	public static class ConstructorWithParamTestEntity extends BasicTestEntity {
-		private final String value;
-
-		public ConstructorWithParamTestEntity(final String value) {
-			super();
-			this.value = value;
-		}
-	}
-
-	@Test
-	public void constructorWithParam() {
-		final ConstructorWithParamTestEntity entity = new ConstructorWithParamTestEntity("test");
-		template.insert(entity);
-		final ConstructorWithParamTestEntity document = template
-				.find(entity.getId(), ConstructorWithParamTestEntity.class).get();
-		assertThat(document, is(notNullValue()));
-		assertThat(document.value, is(entity.value));
-	}
-
-	public static class ConstructorWithMultipleParamsTestEntity extends BasicTestEntity {
-		private final String value1;
-		private final boolean value2;
-		private final double value3;
-		private final long value4;
-		private final int value5;
-		private final String[] value6;
-
-		public ConstructorWithMultipleParamsTestEntity(final String value1, final boolean value2, final double value3,
-			final long value4, final int value5, final String[] value6) {
-			super();
-			this.value1 = value1;
-			this.value2 = value2;
-			this.value3 = value3;
-			this.value4 = value4;
-			this.value5 = value5;
-			this.value6 = value6;
-		}
-
-	}
-
-	@Test
-	public void constructorWithMultipleParams() {
-		final ConstructorWithMultipleParamsTestEntity entity = new ConstructorWithMultipleParamsTestEntity("test", true,
-				3.5, 13L, 69, new String[] { "a", "b" });
-		template.insert(entity);
-		final ConstructorWithMultipleParamsTestEntity document = template
-				.find(entity.getId(), ConstructorWithMultipleParamsTestEntity.class).get();
-		assertThat(document, is(notNullValue()));
-		assertThat(document.value1, is(entity.value1));
-		assertThat(document.value2, is(entity.value2));
-		assertThat(document.value3, is(entity.value3));
-		assertThat(document.value4, is(entity.value4));
-		assertThat(document.value5, is(entity.value5));
-		assertThat(document.value6, is(entity.value6));
-	}
-
-	public static class JodaTestEntity extends BasicTestEntity {
-		private org.joda.time.DateTime value1;
-		private org.joda.time.Instant value2;
-		private org.joda.time.LocalDate value3;
-		private org.joda.time.LocalDateTime value4;
-	}
-
-	@Test
-	public void jodaMapping() {
-		final JodaTestEntity entity = new JodaTestEntity();
-		entity.value1 = org.joda.time.DateTime.now(DateTimeZone.forOffsetHours(1));
-		entity.value2 = org.joda.time.Instant.now();
-		entity.value3 = org.joda.time.LocalDate.now();
-		entity.value4 = org.joda.time.LocalDateTime.now();
-		template.insert(entity);
-		final JodaTestEntity document = template.find(entity.getId(), JodaTestEntity.class).get();
-		assertThat(document, is(notNullValue()));
-		assertThat(document.value1, is(entity.value1));
-		assertThat(document.value2, is(entity.value2));
-		assertThat(document.value3, is(entity.value3));
-		assertThat(document.value4, is(entity.value4));
-	}
-
-	public static class Java8TimeTestEntity extends BasicTestEntity {
-		private java.time.Instant value1;
-		private java.time.LocalDate value2;
-		private java.time.LocalDateTime value3;
-	}
-
-	@Test
-	public void timeMapping() {
-		final Java8TimeTestEntity entity = new Java8TimeTestEntity();
-		entity.value1 = java.time.Instant.now();
-		entity.value2 = java.time.LocalDate.now();
-		entity.value3 = java.time.LocalDateTime.now();
-		template.insert(entity);
-		final Java8TimeTestEntity document = template.find(entity.getId(), Java8TimeTestEntity.class).get();
-		assertThat(document, is(notNullValue()));
-		assertThat(document.value1, is(entity.value1));
-		assertThat(document.value2, is(entity.value2));
-		assertThat(document.value3, is(entity.value3));
-	}
-
-	public class SimpleTypesTestEntity extends BasicTestEntity {
-		private String stringValue;
-		private Boolean boolValue;
-		private int intValue;
-		private Long longValue;
-		private Short shortValue;
-		private Float floatValue;
-		private Double doubleValue;
-		private Character charValue;
-		private Byte byteValue;
-		private BigInteger bigIntValue;
-		private BigDecimal bigDecValue;
-		private UUID uuidValue;
-		private Date dateValue;
-		private java.sql.Date sqlDateValue;
-		private Timestamp timestampValue;
-		private byte[] byteArray;
-	}
-
-	@Test
-	public void simpleTypesMapping() {
-		final SimpleTypesTestEntity entity = new SimpleTypesTestEntity();
-		entity.stringValue = "hello world";
-		entity.boolValue = true;
-		entity.intValue = 123456;
-		entity.longValue = 1234567890123456789l;
-		entity.shortValue = 1234;
-		entity.floatValue = 1.234567890f;
-		entity.doubleValue = 1.2345678901234567890;
-		entity.charValue = 'a';
-		entity.byteValue = 'z';
-		entity.bigIntValue = new BigInteger("123456789");
-		entity.bigDecValue = new BigDecimal("1.23456789");
-		entity.uuidValue = UUID.randomUUID();
-		entity.dateValue = new Date();
-		entity.sqlDateValue = new java.sql.Date(new Date().getTime());
-		entity.timestampValue = new Timestamp(new Date().getTime());
-		entity.byteArray = new byte[] { 'a', 'b', 'c', 'x', 'y', 'z' };
-		template.insert(entity);
-		final SimpleTypesTestEntity document = template.find(entity.getId(), SimpleTypesTestEntity.class).get();
-		assertThat(entity.stringValue, is(document.stringValue));
-		assertThat(entity.boolValue, is(document.boolValue));
-		assertThat(entity.intValue, is(document.intValue));
-		assertThat(entity.longValue, is(document.longValue));
-		assertThat(entity.shortValue, is(document.shortValue));
-		assertThat(entity.floatValue, is(document.floatValue));
-		assertThat(entity.doubleValue, is(document.doubleValue));
-		assertThat(entity.charValue, is(document.charValue));
-		assertThat(entity.byteValue, is(document.byteValue));
-		assertThat(entity.bigIntValue, is(document.bigIntValue));
-		assertThat(entity.bigDecValue, is(document.bigDecValue));
-		assertThat(entity.uuidValue, is(document.uuidValue));
-		assertThat(entity.dateValue, is(document.dateValue));
-		assertThat(entity.sqlDateValue, is(document.sqlDateValue));
-		assertThat(entity.timestampValue, is(document.timestampValue));
-		assertThat(entity.byteArray, is(document.byteArray));
-	}
-
-	public enum TestEnum {
-		A, B;
-	}
-
-	public class EnumTestEntity extends BasicTestEntity {
-		private TestEnum value;
-	}
-
-	@Test
-	public void enumMapping() {
-		final EnumTestEntity entity = new EnumTestEntity();
-		entity.value = TestEnum.A;
-		template.insert(entity);
-		final EnumTestEntity document = template.find(entity.getId(), EnumTestEntity.class).get();
-		assertThat(entity.value, is(document.value));
-	}
-
-	@Test
-	public void cyclicRelationsTest() {
-		final Actor actor = new Actor();
-		actor.setName("George Clooney");
-		template.insert(actor);
-
-		final Movie movie1 = new Movie();
-		movie1.setName("Ocean's Eleven");
-		template.insert(movie1);
-
-		final Movie movie2 = new Movie();
-		movie2.setName("Ocean's Twelve");
-		template.insert(movie2);
-
-		final Movie movie3 = new Movie();
-		movie3.setName("Ocean's Thirteen");
-		template.insert(movie3);
-
-		final Role role1 = new Role();
-		role1.setActor(actor);
-		role1.setMovie(movie1);
-		template.insert(role1);
-
-		final Role role2 = new Role();
-		role2.setActor(actor);
-		role2.setMovie(movie2);
-		template.insert(role2);
-
-		final Role role3 = new Role();
-		role3.setActor(actor);
-		role3.setMovie(movie3);
-		template.insert(role3);
-
-		final Actor retrieved = template.find(actor.getId(), Actor.class).get();
-
-		assertThat(retrieved, is(notNullValue()));
-
-		assertThat(retrieved.getId(), is(actor.getId()));
-		assertThat(retrieved.getName(), is(actor.getName()));
-
-		assertThat(retrieved.getRoles(), is(notNullValue()));
-		assertThat(retrieved.getMovies(), is(notNullValue()));
-
-		for (final Role role : retrieved.getRoles()) {
-			assertThat(role.getActor(), is(notNullValue()));
-			assertThat(role.getActor().getId(), is(actor.getId()));
-			assertThat(role.getActor().getName(), is(actor.getName()));
-
-			assertThat(role.getMovie(), is(notNullValue()));
-			assertThat(role.getMovie().getId(), isOneOf(movie1.getId(), movie2.getId(), movie3.getId()));
-			assertThat(role.getMovie().getName(), isOneOf(movie1.getName(), movie2.getName(), movie3.getName()));
-		}
-
-		for (final Movie movie : retrieved.getMovies()) {
-			assertThat(movie, is(notNullValue()));
-			assertThat(movie.getId(), isOneOf(movie1.getId(), movie2.getId(), movie3.getId()));
-			assertThat(movie.getName(), isOneOf(movie1.getName(), movie2.getName(), movie3.getName()));
-
-			assertThat(movie.getActors(), is(notNullValue()));
-			for (final Actor a : movie.getActors()) {
-				assertThat(a, is(notNullValue()));
-				assertThat(a.getId(), isOneOf(actor.getId()));
-				assertThat(a.getName(), isOneOf(actor.getName()));
-			}
-		}
-
-	}
-
-	@Document("sameCollection")
-	static class TwoTypesInSameCollectionA extends BasicTestEntity {
-		String value;
-		String a;
-	}
-
-	@Document("sameCollection")
-	static class TwoTypesInSameCollectionB extends BasicTestEntity {
-		String value;
-		String b;
-	}
-
-	@Test
-	public void twoTypesInSameCollection() {
-		final TwoTypesInSameCollectionA a = new TwoTypesInSameCollectionA();
-		a.value = "testA";
-		a.a = "testA";
-		final TwoTypesInSameCollectionB b = new TwoTypesInSameCollectionB();
-		b.value = "testB";
-		b.b = "testB";
-
-		template.insert(a);
-		template.insert(b);
-		final Optional<TwoTypesInSameCollectionA> findA = template.find(a.getId(), TwoTypesInSameCollectionA.class);
-		assertThat(findA.isPresent(), is(true));
-		assertThat(findA.get().value, is("testA"));
-		assertThat(findA.get().a, is("testA"));
-		final Optional<TwoTypesInSameCollectionB> findB = template.find(b.getId(), TwoTypesInSameCollectionB.class);
-		assertThat(findB.isPresent(), is(true));
-		assertThat(findB.get().value, is("testB"));
-		assertThat(findB.get().b, is("testB"));
-	}
-
-	static class ArangoIdOnlyTestEntity {
-		@ArangoId
-		private String id;
-	}
-
-	@SuppressWarnings("deprecation")
-	@Test
-	public void arangoIdOnly() {
-		final ArangoIdOnlyTestEntity entity = new ArangoIdOnlyTestEntity();
-		template.upsert(entity, UpsertStrategy.UPDATE);
-		assertThat(entity.id, is(notNullValue()));
-		final Optional<ArangoIdOnlyTestEntity> find = template.find(entity.id, ArangoIdOnlyTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().id, is(entity.id));
-	}
-
-	static class ArangoIdAndIdTestEntity {
-		@ArangoId
-		private String arangoId;
-		@Id
-		private String id;
-	}
-
-	@Test
-	public void arangoIdAndId() {
-		final ArangoIdAndIdTestEntity entity = new ArangoIdAndIdTestEntity();
-		entity.arangoId = "arangoIdAndIdTestEntity/test";
-		template.insert(entity);
-		assertThat(entity.arangoId, is("arangoIdAndIdTestEntity/test"));
-		assertThat(entity.id, is("test"));
-		assertThat(template.find(entity.id, ArangoIdAndIdTestEntity.class).isPresent(), is(true));
-		assertThat(template.find(entity.arangoId, ArangoIdAndIdTestEntity.class).isPresent(), is(true));
-	}
-
-	@Document
-	static class AuditingTestEntity {
-		@Id
-		private String id;
-		@CreatedDate
-		private Instant created;
-		@CreatedBy
-		private Person createdBy;
-		@LastModifiedDate
-		private Instant modified;
-		@Ref
-		@LastModifiedBy
-		private Person modifiedBy;
-	}
-
-	@Autowired
-	AuditorProvider auditorProvider;
-
-	@Test
-	public void auditingTest() throws InterruptedException {
-		final String createID = "create";
-		{
-			final Person person = new Person();
-			person.setId(createID);
-			template.insert(person);
-			auditorProvider.setPerson(person);
-		}
-
-		final Instant beforeInsert = Instant.now();
-		final AuditingTestEntity value = new AuditingTestEntity();
-		template.insert(value);
-		final Instant afterInsert = Instant.now();
-		{
-			final AuditingTestEntity find = template.find(value.id, AuditingTestEntity.class).get();
-			assertThat(find.created, is(notNullValue()));
-			assertThat(find.created.isAfter(beforeInsert), is(true));
-			assertThat(find.created.isBefore(afterInsert), is(true));
-
-			assertThat(find.createdBy, is(notNullValue()));
-			assertThat(find.createdBy.getId(), is(createID));
-
-			assertThat(find.modified, is(notNullValue()));
-			assertThat(find.modified.isAfter(beforeInsert), is(true));
-			assertThat(find.modified.isBefore(afterInsert), is(true));
-
-			assertThat(find.modifiedBy, is(notNullValue()));
-			assertThat(find.modifiedBy.getId(), is(createID));
-		}
-
-		final VPackSlice doc = template.driver().db(ArangoTestConfiguration.DB).collection("auditingTestEntity")
-				.getDocument(value.id, VPackSlice.class);
-		assertThat(doc, is(notNullValue()));
-		assertThat(doc.get("createdBy").isObject(), is(true));
-		assertThat(doc.get("modifiedBy").isString(), is(true));
-
-		final String modifiedID = "modified";
-		{
-			final Person person = new Person();
-			person.setId(modifiedID);
-			template.insert(person);
-			auditorProvider.setPerson(person);
-		}
-
-		final Instant beforeReplace = Instant.now();
-		Thread.sleep(1);
-		template.replace(value.id, value);
-		Thread.sleep(1);
-		final Instant afterReplace = Instant.now();
-		{
-			final AuditingTestEntity find = template.find(value.id, AuditingTestEntity.class).get();
-			assertThat(find.created, is(notNullValue()));
-			assertThat(find.created.isAfter(beforeInsert), is(true));
-			assertThat(find.created.isBefore(afterInsert), is(true));
-
-			assertThat(find.createdBy, is(notNullValue()));
-			assertThat(find.createdBy.getId(), is(createID));
-
-			assertThat(find.modified, is(notNullValue()));
-			assertThat(find.modified.isAfter(beforeReplace), is(true));
-			assertThat(find.modified.isBefore(afterReplace), is(true));
-
-			assertThat(find.modifiedBy, is(notNullValue()));
-			assertThat(find.modifiedBy.getId(), is(modifiedID));
-		}
-	}
-
-	@Document("primitive_test_col")
-	static class NoPrimitiveTestEntity {
-		@Id
-		private String id;
-	}
-
-	@Document("primitive_test_col")
-	static class PrimitiveTestEntity {
-		@Id
-		private String id;
-		@SuppressWarnings("unused")
-		private boolean value;
-	}
-
-	@Test
-	public void readNonExistingPrimitive() {
-		final NoPrimitiveTestEntity entity = new NoPrimitiveTestEntity();
-		template.insert(entity);
-		final Optional<PrimitiveTestEntity> find = template.find(entity.id, PrimitiveTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().id, is(entity.id));
-	}
-
-	@Document
-	static class ObjectFieldTestEntity {
-		@Id
-		private String id;
-		private Object value;
-	}
-
-	@Test
-	public void readObjectFieldFromString() {
-		final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
-		entity.value = "test";
-		template.insert(entity);
-		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().value, is("test"));
-	}
-
-	@Test
-	public void readObjectFieldFromMap() {
-		final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
-		final HashMap<Object, Object> map = new HashMap<>();
-		map.put("key", "value");
-		entity.value = map;
-		template.insert(entity);
-		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().value, is(map));
-	}
-
-	@Test
-	public void readObjectFieldFromCollectionLike() {
-		final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
-		final Collection<String> collection = Arrays.asList("test", "test");
-		entity.value = collection;
-		template.insert(entity);
-		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().value, is(collection));
-	}
-
-	@Test
-	public void readObjectFieldFromPOJO() {
-		final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
-		final SimpleTypesTestEntity value = new SimpleTypesTestEntity();
-		value.stringValue = "test";
-		entity.value = value;
-		template.insert(entity);
-		final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().value instanceof SimpleTypesTestEntity, is(true));
-		assertThat(SimpleTypesTestEntity.class.cast(find.get().value).stringValue, is("test"));
-	}
-
-	@Document
-	static class MapInMapTestEntity {
-		@Id
-		private String id;
-		private Map<String, Object> value;
-	}
-
-	@Test
-	public void readMapInMap() {
-		final MapInMapTestEntity entity = new MapInMapTestEntity();
-		final Map<String, Object> map = new HashMap<>();
-		map.put("map", new HashMap<>());
-		entity.value = map;
-		template.insert(entity);
-		final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		assertThat(find.get().value, is(map));
-	}
-
-	@Test
-	public void readMapInMapWithNull() {
-		final MapInMapTestEntity entity = new MapInMapTestEntity();
-		final Map<String, Object> map = new HashMap<>();
-		Map<String, Object> nested = new HashMap<>();
-		nested.put("key1", "test");
-		nested.put("key2", null);
-		map.put("nested", nested);
-		entity.value = map;
-		template.insert(entity);
-		final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
-		assertThat(nestedResult.size(), is(1));
-		assertThat(nestedResult.get("key1"), is("test"));
-	}
-
-	@Test
-	public void readMapInMapWithArray() {
-		final MapInMapTestEntity entity = new MapInMapTestEntity();
-		final Map<String, Object> map = new HashMap<>();
-		Map<String, Object> nested = new HashMap<>();
-		String[] nestedArray = {"test", null};
-		nested.put("key1", nestedArray);
-		map.put("nested", nested);
-		entity.value = map;
-		template.insert(entity);
-		final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
-		assertThat(nestedResult.size(), is(1));
-		assertThat(((List<String>) nestedResult.get("key1")).size(), is(2));
-		assertEquals(Arrays.asList(nestedArray), nestedResult.get("key1"));
-	}
-
-	@Test
-	public void readMapInMapWithCollection() {
-		final MapInMapTestEntity entity = new MapInMapTestEntity();
-		final Map<String, Object> map = new HashMap<>();
-		Map<String, Object> nested = new HashMap<>();
-		Collection<String> nestedCollection = Arrays.asList("test", null);
-		nested.put("key1", nestedCollection);
-		map.put("nested", nested);
-		entity.value = map;
-		template.insert(entity);
-		final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
-		assertThat(find.isPresent(), is(true));
-		Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
-		assertThat(nestedResult.size(), is(1));
-		assertThat(((List<String>) nestedResult.get("key1")).size(), is(2));
-		assertEquals(nestedCollection, nestedResult.get("key1"));
-	}
+    @Test
+    public void idKeyRev() {
+        final DocumentEntity ref = template.insert(new BasicTestEntity());
+        final BasicTestEntity entity = template.find(ref.getId(), BasicTestEntity.class).get();
+        assertThat(entity, is(notNullValue()));
+        assertThat(entity.getId(), is(ref.getKey()));
+        assertThat(entity.getRev(), is(ref.getRev()));
+    }
+
+    public static class OnlyIdTestEntity {
+        @Id
+        private String id;
+    }
+
+    @Test
+    public void supplementKey() {
+        final OnlyIdTestEntity value = new OnlyIdTestEntity();
+        template.insert(value);
+        final List<BasicTestEntity> result = template.query("RETURN @doc", new MapBuilder().put("doc", value).get(),
+                new AqlQueryOptions(), BasicTestEntity.class).asListRemaining();
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0).getId(), is(value.id));
+        assertThat(result.get(0).getRev(), is(nullValue()));
+    }
+
+    public static class FieldNameTestEntity extends BasicTestEntity {
+        @Field("alt-test")
+        private String test;
+    }
+
+    @Test
+    public void fieldNameAnnotation() {
+        final FieldNameTestEntity entity = new FieldNameTestEntity();
+        entity.test = "1234";
+        final DocumentEntity res = template.insert(entity);
+        final VPackSlice slice = template.driver().db(ArangoTestConfiguration.DB).getDocument(res.getId(),
+                VPackSlice.class);
+        assertThat(slice, is(notNullValue()));
+        assertThat(slice.get("alt-test").isString(), is(true));
+        assertThat(slice.get("alt-test").getAsString(), is(entity.test));
+    }
+
+    public static class ConstructorWithParamTestEntity extends BasicTestEntity {
+        private final String value;
+
+        public ConstructorWithParamTestEntity(final String value) {
+            super();
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void constructorWithParam() {
+        final ConstructorWithParamTestEntity entity = new ConstructorWithParamTestEntity("test");
+        template.insert(entity);
+        final ConstructorWithParamTestEntity document = template
+                .find(entity.getId(), ConstructorWithParamTestEntity.class).get();
+        assertThat(document, is(notNullValue()));
+        assertThat(document.value, is(entity.value));
+    }
+
+    public static class ConstructorWithMultipleParamsTestEntity extends BasicTestEntity {
+        private final String value1;
+        private final boolean value2;
+        private final double value3;
+        private final long value4;
+        private final int value5;
+        private final String[] value6;
+
+        public ConstructorWithMultipleParamsTestEntity(final String value1, final boolean value2, final double value3,
+                                                       final long value4, final int value5, final String[] value6) {
+            super();
+            this.value1 = value1;
+            this.value2 = value2;
+            this.value3 = value3;
+            this.value4 = value4;
+            this.value5 = value5;
+            this.value6 = value6;
+        }
+
+    }
+
+    @Test
+    public void constructorWithMultipleParams() {
+        final ConstructorWithMultipleParamsTestEntity entity = new ConstructorWithMultipleParamsTestEntity("test", true,
+                3.5, 13L, 69, new String[]{"a", "b"});
+        template.insert(entity);
+        final ConstructorWithMultipleParamsTestEntity document = template
+                .find(entity.getId(), ConstructorWithMultipleParamsTestEntity.class).get();
+        assertThat(document, is(notNullValue()));
+        assertThat(document.value1, is(entity.value1));
+        assertThat(document.value2, is(entity.value2));
+        assertThat(document.value3, is(entity.value3));
+        assertThat(document.value4, is(entity.value4));
+        assertThat(document.value5, is(entity.value5));
+        assertThat(document.value6, is(entity.value6));
+    }
+
+    public static class GeoTestEntity extends BasicTestEntity {
+        private Point point;
+        private GeoJsonPoint geoJsonPoint;
+        private GeoJson<?> geoJson;
+    }
+
+    @Test
+    public void geoMapping() {
+        ArangoConverter converter = template.getConverter();
+
+        GeoTestEntity entity = new GeoTestEntity();
+        entity.point = new Point(1.1, 2.2);
+        entity.geoJsonPoint = new GeoJsonPoint(3.3, 4.4);
+        entity.geoJson = new GeoJsonPoint(5.5, 6.6);
+        VPackSlice written = converter.write(entity);
+
+//        DBDocumentEntity dbe = converter.read(DBDocumentEntity.class, written);
+        // TODO: assert dbe is valid geoJson
+
+        GeoTestEntity read = converter.read(GeoTestEntity.class, written);
+        assertThat(read.point, is(entity.point));
+        assertThat(read.geoJsonPoint, is(entity.geoJsonPoint));
+        assertThat(read.geoJson, is(entity.geoJson));
+    }
+
+    public static class JodaTestEntity extends BasicTestEntity {
+        private org.joda.time.DateTime value1;
+        private org.joda.time.Instant value2;
+        private org.joda.time.LocalDate value3;
+        private org.joda.time.LocalDateTime value4;
+    }
+
+    @Test
+    public void jodaMapping() {
+        final JodaTestEntity entity = new JodaTestEntity();
+        entity.value1 = org.joda.time.DateTime.now(DateTimeZone.forOffsetHours(1));
+        entity.value2 = org.joda.time.Instant.now();
+        entity.value3 = org.joda.time.LocalDate.now();
+        entity.value4 = org.joda.time.LocalDateTime.now();
+        template.insert(entity);
+        final JodaTestEntity document = template.find(entity.getId(), JodaTestEntity.class).get();
+        assertThat(document, is(notNullValue()));
+        assertThat(document.value1, is(entity.value1));
+        assertThat(document.value2, is(entity.value2));
+        assertThat(document.value3, is(entity.value3));
+        assertThat(document.value4, is(entity.value4));
+    }
+
+    public static class Java8TimeTestEntity extends BasicTestEntity {
+        private java.time.Instant value1;
+        private java.time.LocalDate value2;
+        private java.time.LocalDateTime value3;
+    }
+
+    @Test
+    public void timeMapping() {
+        final Java8TimeTestEntity entity = new Java8TimeTestEntity();
+        entity.value1 = java.time.Instant.now();
+        entity.value2 = java.time.LocalDate.now();
+        entity.value3 = java.time.LocalDateTime.now();
+        template.insert(entity);
+        final Java8TimeTestEntity document = template.find(entity.getId(), Java8TimeTestEntity.class).get();
+        assertThat(document, is(notNullValue()));
+        assertThat(document.value1, is(entity.value1));
+        assertThat(document.value2, is(entity.value2));
+        assertThat(document.value3, is(entity.value3));
+    }
+
+    public class SimpleTypesTestEntity extends BasicTestEntity {
+        private String stringValue;
+        private Boolean boolValue;
+        private int intValue;
+        private Long longValue;
+        private Short shortValue;
+        private Float floatValue;
+        private Double doubleValue;
+        private Character charValue;
+        private Byte byteValue;
+        private BigInteger bigIntValue;
+        private BigDecimal bigDecValue;
+        private UUID uuidValue;
+        private Date dateValue;
+        private java.sql.Date sqlDateValue;
+        private Timestamp timestampValue;
+        private byte[] byteArray;
+    }
+
+    @Test
+    public void simpleTypesMapping() {
+        final SimpleTypesTestEntity entity = new SimpleTypesTestEntity();
+        entity.stringValue = "hello world";
+        entity.boolValue = true;
+        entity.intValue = 123456;
+        entity.longValue = 1234567890123456789l;
+        entity.shortValue = 1234;
+        entity.floatValue = 1.234567890f;
+        entity.doubleValue = 1.2345678901234567890;
+        entity.charValue = 'a';
+        entity.byteValue = 'z';
+        entity.bigIntValue = new BigInteger("123456789");
+        entity.bigDecValue = new BigDecimal("1.23456789");
+        entity.uuidValue = UUID.randomUUID();
+        entity.dateValue = new Date();
+        entity.sqlDateValue = new java.sql.Date(new Date().getTime());
+        entity.timestampValue = new Timestamp(new Date().getTime());
+        entity.byteArray = new byte[]{'a', 'b', 'c', 'x', 'y', 'z'};
+        template.insert(entity);
+        final SimpleTypesTestEntity document = template.find(entity.getId(), SimpleTypesTestEntity.class).get();
+        assertThat(entity.stringValue, is(document.stringValue));
+        assertThat(entity.boolValue, is(document.boolValue));
+        assertThat(entity.intValue, is(document.intValue));
+        assertThat(entity.longValue, is(document.longValue));
+        assertThat(entity.shortValue, is(document.shortValue));
+        assertThat(entity.floatValue, is(document.floatValue));
+        assertThat(entity.doubleValue, is(document.doubleValue));
+        assertThat(entity.charValue, is(document.charValue));
+        assertThat(entity.byteValue, is(document.byteValue));
+        assertThat(entity.bigIntValue, is(document.bigIntValue));
+        assertThat(entity.bigDecValue, is(document.bigDecValue));
+        assertThat(entity.uuidValue, is(document.uuidValue));
+        assertThat(entity.dateValue, is(document.dateValue));
+        assertThat(entity.sqlDateValue, is(document.sqlDateValue));
+        assertThat(entity.timestampValue, is(document.timestampValue));
+        assertThat(entity.byteArray, is(document.byteArray));
+    }
+
+    public enum TestEnum {
+        A, B;
+    }
+
+    public class EnumTestEntity extends BasicTestEntity {
+        private TestEnum value;
+    }
+
+    @Test
+    public void enumMapping() {
+        final EnumTestEntity entity = new EnumTestEntity();
+        entity.value = TestEnum.A;
+        template.insert(entity);
+        final EnumTestEntity document = template.find(entity.getId(), EnumTestEntity.class).get();
+        assertThat(entity.value, is(document.value));
+    }
+
+    @Test
+    public void cyclicRelationsTest() {
+        final Actor actor = new Actor();
+        actor.setName("George Clooney");
+        template.insert(actor);
+
+        final Movie movie1 = new Movie();
+        movie1.setName("Ocean's Eleven");
+        template.insert(movie1);
+
+        final Movie movie2 = new Movie();
+        movie2.setName("Ocean's Twelve");
+        template.insert(movie2);
+
+        final Movie movie3 = new Movie();
+        movie3.setName("Ocean's Thirteen");
+        template.insert(movie3);
+
+        final Role role1 = new Role();
+        role1.setActor(actor);
+        role1.setMovie(movie1);
+        template.insert(role1);
+
+        final Role role2 = new Role();
+        role2.setActor(actor);
+        role2.setMovie(movie2);
+        template.insert(role2);
+
+        final Role role3 = new Role();
+        role3.setActor(actor);
+        role3.setMovie(movie3);
+        template.insert(role3);
+
+        final Actor retrieved = template.find(actor.getId(), Actor.class).get();
+
+        assertThat(retrieved, is(notNullValue()));
+
+        assertThat(retrieved.getId(), is(actor.getId()));
+        assertThat(retrieved.getName(), is(actor.getName()));
+
+        assertThat(retrieved.getRoles(), is(notNullValue()));
+        assertThat(retrieved.getMovies(), is(notNullValue()));
+
+        for (final Role role : retrieved.getRoles()) {
+            assertThat(role.getActor(), is(notNullValue()));
+            assertThat(role.getActor().getId(), is(actor.getId()));
+            assertThat(role.getActor().getName(), is(actor.getName()));
+
+            assertThat(role.getMovie(), is(notNullValue()));
+            assertThat(role.getMovie().getId(), isOneOf(movie1.getId(), movie2.getId(), movie3.getId()));
+            assertThat(role.getMovie().getName(), isOneOf(movie1.getName(), movie2.getName(), movie3.getName()));
+        }
+
+        for (final Movie movie : retrieved.getMovies()) {
+            assertThat(movie, is(notNullValue()));
+            assertThat(movie.getId(), isOneOf(movie1.getId(), movie2.getId(), movie3.getId()));
+            assertThat(movie.getName(), isOneOf(movie1.getName(), movie2.getName(), movie3.getName()));
+
+            assertThat(movie.getActors(), is(notNullValue()));
+            for (final Actor a : movie.getActors()) {
+                assertThat(a, is(notNullValue()));
+                assertThat(a.getId(), isOneOf(actor.getId()));
+                assertThat(a.getName(), isOneOf(actor.getName()));
+            }
+        }
+
+    }
+
+    @Document("sameCollection")
+    static class TwoTypesInSameCollectionA extends BasicTestEntity {
+        String value;
+        String a;
+    }
+
+    @Document("sameCollection")
+    static class TwoTypesInSameCollectionB extends BasicTestEntity {
+        String value;
+        String b;
+    }
+
+    @Test
+    public void twoTypesInSameCollection() {
+        final TwoTypesInSameCollectionA a = new TwoTypesInSameCollectionA();
+        a.value = "testA";
+        a.a = "testA";
+        final TwoTypesInSameCollectionB b = new TwoTypesInSameCollectionB();
+        b.value = "testB";
+        b.b = "testB";
+
+        template.insert(a);
+        template.insert(b);
+        final Optional<TwoTypesInSameCollectionA> findA = template.find(a.getId(), TwoTypesInSameCollectionA.class);
+        assertThat(findA.isPresent(), is(true));
+        assertThat(findA.get().value, is("testA"));
+        assertThat(findA.get().a, is("testA"));
+        final Optional<TwoTypesInSameCollectionB> findB = template.find(b.getId(), TwoTypesInSameCollectionB.class);
+        assertThat(findB.isPresent(), is(true));
+        assertThat(findB.get().value, is("testB"));
+        assertThat(findB.get().b, is("testB"));
+    }
+
+    static class ArangoIdOnlyTestEntity {
+        @ArangoId
+        private String id;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void arangoIdOnly() {
+        final ArangoIdOnlyTestEntity entity = new ArangoIdOnlyTestEntity();
+        template.upsert(entity, UpsertStrategy.UPDATE);
+        assertThat(entity.id, is(notNullValue()));
+        final Optional<ArangoIdOnlyTestEntity> find = template.find(entity.id, ArangoIdOnlyTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().id, is(entity.id));
+    }
+
+    static class ArangoIdAndIdTestEntity {
+        @ArangoId
+        private String arangoId;
+        @Id
+        private String id;
+    }
+
+    @Test
+    public void arangoIdAndId() {
+        final ArangoIdAndIdTestEntity entity = new ArangoIdAndIdTestEntity();
+        entity.arangoId = "arangoIdAndIdTestEntity/test";
+        template.insert(entity);
+        assertThat(entity.arangoId, is("arangoIdAndIdTestEntity/test"));
+        assertThat(entity.id, is("test"));
+        assertThat(template.find(entity.id, ArangoIdAndIdTestEntity.class).isPresent(), is(true));
+        assertThat(template.find(entity.arangoId, ArangoIdAndIdTestEntity.class).isPresent(), is(true));
+    }
+
+    @Document
+    static class AuditingTestEntity {
+        @Id
+        private String id;
+        @CreatedDate
+        private Instant created;
+        @CreatedBy
+        private Person createdBy;
+        @LastModifiedDate
+        private Instant modified;
+        @Ref
+        @LastModifiedBy
+        private Person modifiedBy;
+    }
+
+    @Autowired
+    AuditorProvider auditorProvider;
+
+    @Test
+    public void auditingTest() throws InterruptedException {
+        final String createID = "create";
+        {
+            final Person person = new Person();
+            person.setId(createID);
+            template.insert(person);
+            auditorProvider.setPerson(person);
+        }
+
+        final Instant beforeInsert = Instant.now();
+        final AuditingTestEntity value = new AuditingTestEntity();
+        template.insert(value);
+        final Instant afterInsert = Instant.now();
+        {
+            final AuditingTestEntity find = template.find(value.id, AuditingTestEntity.class).get();
+            assertThat(find.created, is(notNullValue()));
+            assertThat(find.created.isAfter(beforeInsert), is(true));
+            assertThat(find.created.isBefore(afterInsert), is(true));
+
+            assertThat(find.createdBy, is(notNullValue()));
+            assertThat(find.createdBy.getId(), is(createID));
+
+            assertThat(find.modified, is(notNullValue()));
+            assertThat(find.modified.isAfter(beforeInsert), is(true));
+            assertThat(find.modified.isBefore(afterInsert), is(true));
+
+            assertThat(find.modifiedBy, is(notNullValue()));
+            assertThat(find.modifiedBy.getId(), is(createID));
+        }
+
+        final VPackSlice doc = template.driver().db(ArangoTestConfiguration.DB).collection("auditingTestEntity")
+                .getDocument(value.id, VPackSlice.class);
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.get("createdBy").isObject(), is(true));
+        assertThat(doc.get("modifiedBy").isString(), is(true));
+
+        final String modifiedID = "modified";
+        {
+            final Person person = new Person();
+            person.setId(modifiedID);
+            template.insert(person);
+            auditorProvider.setPerson(person);
+        }
+
+        final Instant beforeReplace = Instant.now();
+        Thread.sleep(1);
+        template.replace(value.id, value);
+        Thread.sleep(1);
+        final Instant afterReplace = Instant.now();
+        {
+            final AuditingTestEntity find = template.find(value.id, AuditingTestEntity.class).get();
+            assertThat(find.created, is(notNullValue()));
+            assertThat(find.created.isAfter(beforeInsert), is(true));
+            assertThat(find.created.isBefore(afterInsert), is(true));
+
+            assertThat(find.createdBy, is(notNullValue()));
+            assertThat(find.createdBy.getId(), is(createID));
+
+            assertThat(find.modified, is(notNullValue()));
+            assertThat(find.modified.isAfter(beforeReplace), is(true));
+            assertThat(find.modified.isBefore(afterReplace), is(true));
+
+            assertThat(find.modifiedBy, is(notNullValue()));
+            assertThat(find.modifiedBy.getId(), is(modifiedID));
+        }
+    }
+
+    @Document("primitive_test_col")
+    static class NoPrimitiveTestEntity {
+        @Id
+        private String id;
+    }
+
+    @Document("primitive_test_col")
+    static class PrimitiveTestEntity {
+        @Id
+        private String id;
+        @SuppressWarnings("unused")
+        private boolean value;
+    }
+
+    @Test
+    public void readNonExistingPrimitive() {
+        final NoPrimitiveTestEntity entity = new NoPrimitiveTestEntity();
+        template.insert(entity);
+        final Optional<PrimitiveTestEntity> find = template.find(entity.id, PrimitiveTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().id, is(entity.id));
+    }
+
+    @Document
+    static class ObjectFieldTestEntity {
+        @Id
+        private String id;
+        private Object value;
+    }
+
+    @Test
+    public void readObjectFieldFromString() {
+        final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
+        entity.value = "test";
+        template.insert(entity);
+        final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().value, is("test"));
+    }
+
+    @Test
+    public void readObjectFieldFromMap() {
+        final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
+        final HashMap<Object, Object> map = new HashMap<>();
+        map.put("key", "value");
+        entity.value = map;
+        template.insert(entity);
+        final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().value, is(map));
+    }
+
+    @Test
+    public void readObjectFieldFromCollectionLike() {
+        final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
+        final Collection<String> collection = Arrays.asList("test", "test");
+        entity.value = collection;
+        template.insert(entity);
+        final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().value, is(collection));
+    }
+
+    @Test
+    public void readObjectFieldFromPOJO() {
+        final ObjectFieldTestEntity entity = new ObjectFieldTestEntity();
+        final SimpleTypesTestEntity value = new SimpleTypesTestEntity();
+        value.stringValue = "test";
+        entity.value = value;
+        template.insert(entity);
+        final Optional<ObjectFieldTestEntity> find = template.find(entity.id, ObjectFieldTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().value instanceof SimpleTypesTestEntity, is(true));
+        assertThat(SimpleTypesTestEntity.class.cast(find.get().value).stringValue, is("test"));
+    }
+
+    @Document
+    static class MapInMapTestEntity {
+        @Id
+        private String id;
+        private Map<String, Object> value;
+    }
+
+    @Test
+    public void readMapInMap() {
+        final MapInMapTestEntity entity = new MapInMapTestEntity();
+        final Map<String, Object> map = new HashMap<>();
+        map.put("map", new HashMap<>());
+        entity.value = map;
+        template.insert(entity);
+        final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        assertThat(find.get().value, is(map));
+    }
+
+    @Test
+    public void readMapInMapWithNull() {
+        final MapInMapTestEntity entity = new MapInMapTestEntity();
+        final Map<String, Object> map = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("key1", "test");
+        nested.put("key2", null);
+        map.put("nested", nested);
+        entity.value = map;
+        template.insert(entity);
+        final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
+        assertThat(nestedResult.size(), is(1));
+        assertThat(nestedResult.get("key1"), is("test"));
+    }
+
+    @Test
+    public void readMapInMapWithArray() {
+        final MapInMapTestEntity entity = new MapInMapTestEntity();
+        final Map<String, Object> map = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        String[] nestedArray = {"test", null};
+        nested.put("key1", nestedArray);
+        map.put("nested", nested);
+        entity.value = map;
+        template.insert(entity);
+        final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
+        assertThat(nestedResult.size(), is(1));
+        assertThat(((List<String>) nestedResult.get("key1")).size(), is(2));
+        assertEquals(Arrays.asList(nestedArray), nestedResult.get("key1"));
+    }
+
+    @Test
+    public void readMapInMapWithCollection() {
+        final MapInMapTestEntity entity = new MapInMapTestEntity();
+        final Map<String, Object> map = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        Collection<String> nestedCollection = Arrays.asList("test", null);
+        nested.put("key1", nestedCollection);
+        map.put("nested", nested);
+        entity.value = map;
+        template.insert(entity);
+        final Optional<MapInMapTestEntity> find = template.find(entity.id, MapInMapTestEntity.class);
+        assertThat(find.isPresent(), is(true));
+        Map<String, Object> nestedResult = (Map<String, Object>) find.get().value.get("nested");
+        assertThat(nestedResult.size(), is(1));
+        assertThat(((List<String>) nestedResult.get("key1")).size(), is(2));
+        assertEquals(nestedCollection, nestedResult.get("key1"));
+    }
 }

--- a/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
+++ b/src/test/java/com/arangodb/springframework/core/mapping/GeneralMappingTest.java
@@ -173,7 +173,7 @@ public class GeneralMappingTest extends AbstractArangoTest {
         private GeoJsonMultiLineString geoJsonMultiLineString;
         private Polygon polygon;
         private GeoJsonPolygon geoJsonPolygon;
-
+        private GeoJsonMultiPolygon geoJsonMultiPolygon;
     }
 
     @Test
@@ -215,6 +215,23 @@ public class GeneralMappingTest extends AbstractArangoTest {
                 new Point(0.1, 0.2),
                 new Point(0.3, 0.4),
                 new Point(0.5, 0.6)
+        ));
+
+        entity.geoJsonMultiPolygon = new GeoJsonMultiPolygon(Arrays.asList(
+                new GeoJsonPolygon(Arrays.asList(
+                        new Point(10.1, 10.2),
+                        new Point(10.3, 10.4),
+                        new Point(10.5, 10.6)
+                )),
+                new GeoJsonPolygon(Arrays.asList(
+                        new Point(1.1, 1.2),
+                        new Point(1.3, 1.4),
+                        new Point(1.5, 1.6)
+                )).withInnerRing(Arrays.asList(
+                        new Point(0.1, 0.2),
+                        new Point(0.3, 0.4),
+                        new Point(0.5, 0.6)
+                ))
         ));
 
         VPackSlice written = converter.write(entity);
@@ -268,6 +285,19 @@ public class GeneralMappingTest extends AbstractArangoTest {
                         "[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]" +
                         "] }",
                 json.getJSONObject("geoJsonPolygon"),
+                false);
+        assertThat(read.geoJsonMultiPolygon, is(entity.geoJsonMultiPolygon));
+        JSONAssert.assertEquals(
+                "{ type: MultiPolygon, coordinates: [" +
+                        "   [" +
+                        "      [[1.1, 1.2], [1.3, 1.4], [1.5, 1.6]], " +
+                        "      [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]" +
+                        "   ]," +
+                        "   [" +
+                        "      [[10.1, 10.2], [10.3, 10.4], [10.5, 10.6]] " +
+                        "   ]" +
+                        "] }",
+                json.getJSONObject("geoJsonMultiPolygon"),
                 false);
     }
 

--- a/src/test/java/com/arangodb/springframework/core/template/ArangoIndexTest.java
+++ b/src/test/java/com/arangodb/springframework/core/template/ArangoIndexTest.java
@@ -41,6 +41,7 @@ import com.arangodb.springframework.annotation.SkiplistIndexed;
 import com.arangodb.springframework.annotation.SkiplistIndexes;
 import com.arangodb.springframework.annotation.TtlIndex;
 import com.arangodb.springframework.annotation.TtlIndexed;
+import com.arangodb.springframework.core.geo.GeoJsonPoint;
 import org.junit.Test;
 import org.springframework.data.mapping.MappingException;
 
@@ -350,11 +351,27 @@ public class ArangoIndexTest extends AbstractArangoTest {
 	public void singleFieldGeoIndexed() {
 		assertThat(template.collection(GeoIndexedSingleFieldTestEntity.class).getIndexes().size(), is(2));
 		assertThat(template.collection(GeoIndexedSingleFieldTestEntity.class).getIndexes().stream()
-				.map(i -> i.getType()).collect(Collectors.toList()),
-			hasItems(IndexType.primary, geo1()));
+						.map(i -> i.getType()).collect(Collectors.toList()),
+				hasItems(IndexType.primary, geo1()));
 		assertThat(template.collection(GeoIndexedSingleFieldTestEntity.class).getIndexes().stream()
-				.filter(i -> i.getType() == geo1()).findFirst().get().getFields(),
-			hasItems("a"));
+						.filter(i -> i.getType() == geo1()).findFirst().get().getFields(),
+				hasItems("a"));
+	}
+
+	public static class GeoIndexedGeoJsonFieldTestEntity {
+		@GeoIndexed(geoJson = true)
+		private GeoJsonPoint a;
+	}
+
+	@Test
+	public void geoJsonFieldGeoIndexed() {
+		assertThat(template.collection(GeoIndexedGeoJsonFieldTestEntity.class).getIndexes().size(), is(2));
+		assertThat(template.collection(GeoIndexedGeoJsonFieldTestEntity.class).getIndexes().stream()
+						.map(i -> i.getType()).collect(Collectors.toList()),
+				hasItems(IndexType.primary, geo1()));
+		assertThat(template.collection(GeoIndexedGeoJsonFieldTestEntity.class).getIndexes().stream()
+						.filter(i -> i.getType() == geo1()).findFirst().get().getFields(),
+				hasItems("a"));
 	}
 
 	public static class GeoIndexedMultipleSingleFieldTestEntity {

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -130,6 +130,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	List<Customer> findByLocationWithin(Box box);
 
+	List<Customer> findByPositionWithin(Box box);
+
 	Collection<Customer> findByLocationWithinAndLocationWithinOrName(
 		Point location,
 		int distance,

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -208,6 +208,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	GeoPage<Customer> findByLocationNear(Point location, Pageable pageable);
 
+	GeoPage<Customer> findByPositionNear(Point location, Pageable pageable);
+
 	GeoResults<Customer> findByNameOrSurnameAndLocationWithinOrLocationWithin(
 		String name,
 		String surname,

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -138,6 +138,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	List<Customer> findByLocationWithin(Polygon polygon);
 
+	List<Customer> findByPositionWithin(Polygon polygon);
+
 	List<Customer> findByNameOrLocationWithinOrNameAndSurnameOrNameAndLocationNearAndSurnameAndLocationWithin(
 		String name1,
 		Point location1,

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -137,26 +137,44 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 	List<Customer> findByPositionWithin(Box box);
 
 	Collection<Customer> findByLocationWithinAndLocationWithinOrName(
-		Point location,
-		int distance,
-		Ring<?> ring,
-		String name);
+			Point location,
+			int distance,
+			Ring<?> ring,
+			String name);
+
+	Collection<Customer> findByPositionWithinAndPositionWithinOrName(
+			Point location,
+			int distance,
+			Ring<?> ring,
+			String name);
 
 	List<Customer> findByLocationWithin(Polygon polygon);
 
 	List<Customer> findByPositionWithin(Polygon polygon);
 
 	List<Customer> findByNameOrLocationWithinOrNameAndSurnameOrNameAndLocationNearAndSurnameAndLocationWithin(
-		String name1,
-		Point location1,
-		double distance,
-		String name2,
-		String surname1,
-		String name3,
-		Point location2,
-		String surname2,
-		Point location3,
-		Range<Double> distanceRange);
+			String name1,
+			Point location1,
+			double distance,
+			String name2,
+			String surname1,
+			String name3,
+			Point location2,
+			String surname2,
+			Point location3,
+			Range<Double> distanceRange);
+
+	List<Customer> findByNameOrPositionWithinOrNameAndSurnameOrNameAndPositionNearAndSurnameAndPositionWithin(
+			String name1,
+			Point location1,
+			double distance,
+			String name2,
+			String surname1,
+			String name3,
+			Point location2,
+			String surname2,
+			Point location3,
+			Range<Double> distanceRange);
 
 	// EXISTS
 

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -204,6 +204,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	GeoResults<Customer> findByLocationWithin(Point location, Range<Double> distanceRange);
 
+	GeoResults<Customer> findByPositionWithin(Point location, Range<Double> distanceRange);
+
 	GeoPage<Customer> findByLocationNear(Point location, Pageable pageable);
 
 	GeoResults<Customer> findByNameOrSurnameAndLocationWithinOrLocationWithin(

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -126,6 +126,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	List<Customer> findByLocationWithinAndName(Point location, Range<Double> distanceRange, String name);
 
+	List<Customer> findByPositionWithinAndName(Point location, Range<Double> distanceRange, String name);
+
 	Iterable<Customer> findByLocationWithinOrNameAndLocationNear(Circle circle, String name, Point location2);
 
 	List<Customer> findByLocationWithin(Box box);

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -122,6 +122,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	Customer[] findByLocationNear(Point location);
 
+	Customer[] findByPositionNear(Point location);
+
 	List<Customer> findByLocationWithinAndName(Point location, Range<Double> distanceRange, String name);
 
 	Iterable<Customer> findByLocationWithinOrNameAndLocationNear(Circle circle, String name, Point location2);

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -211,12 +211,20 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 	GeoPage<Customer> findByPositionNear(Point location, Pageable pageable);
 
 	GeoResults<Customer> findByNameOrSurnameAndLocationWithinOrLocationWithin(
-		String name,
-		String surname,
-		Point location1,
-		Distance distance,
-		Point location2,
-		Range<Distance> distanceRange);
+			String name,
+			String surname,
+			Point location1,
+			Distance distance,
+			Point location2,
+			Range<Distance> distanceRange);
+
+	GeoResults<Customer> findByNameOrSurnameAndPositionWithinOrPositionWithin(
+			String name,
+			String surname,
+			Point location1,
+			Distance distance,
+			Point location2,
+			Range<Distance> distanceRange);
 
 	// NESTED PROPERTIES
 

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -130,6 +130,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	Iterable<Customer> findByLocationWithinOrNameAndLocationNear(Circle circle, String name, Point location2);
 
+	Iterable<Customer> findByPositionWithinOrNameAndPositionNear(Circle circle, String name, Point location2);
+
 	List<Customer> findByLocationWithin(Box box);
 
 	List<Customer> findByPositionWithin(Box box);

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -200,6 +200,8 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
 	GeoResult<Customer> queryByLocationWithin(Point location, double distance);
 
+	GeoResult<Customer> queryByPositionWithin(Point location, double distance);
+
 	GeoResults<Customer> findByLocationWithin(Point location, Range<Double> distanceRange);
 
 	GeoPage<Customer> findByLocationNear(Point location, Pageable pageable);

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -669,7 +669,35 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		final Bound<Double> lowerBound = Bound.inclusive(convertAngleToDistance(30));
 		final Bound<Double> upperBound = Bound.inclusive(convertAngleToDistance(50));
 		final GeoResults<Customer> retrieved = repository.findByLocationWithin(new Point(1, 0),
-			Range.of(lowerBound, upperBound));
+				Range.of(lowerBound, upperBound));
+		final List<GeoResult<Customer>> expectedGeoResults = new LinkedList<>();
+		expectedGeoResults.add(new GeoResult<>(customer1,
+				new Distance(getDistanceBetweenPoints(new Point(1, 0), new Point(21, 43)) / 1000, Metrics.KILOMETERS)));
+		expectedGeoResults.add(new GeoResult<>(customer2,
+				new Distance(getDistanceBetweenPoints(new Point(1, 0), new Point(43, 21)) / 1000, Metrics.KILOMETERS)));
+		assertTrue(equals(expectedGeoResults, retrieved, geoCmp, geoEq, false));
+	}
+
+	@Test
+	public void geoJsonGeoResultsTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("", "", 0);
+		customer1.setPosition(new Point ( 21, 43 ));
+		toBeRetrieved.add(customer1);
+		final Customer customer2 = new Customer("", "", 0);
+		customer2.setPosition(new Point ( 43, 21 ));
+		toBeRetrieved.add(customer2);
+		repository.saveAll(toBeRetrieved);
+		final Customer customer3 = new Customer("", "", 0);
+		customer3.setPosition(new Point ( 50, 70 ));
+		repository.save(customer3);
+		final Customer customer4 = new Customer("", "", 0);
+		customer4.setPosition(new Point ( 2, 3 ));
+		repository.save(customer4);
+		final Bound<Double> lowerBound = Bound.inclusive(convertAngleToDistance(30));
+		final Bound<Double> upperBound = Bound.inclusive(convertAngleToDistance(50));
+		final GeoResults<Customer> retrieved = repository.findByPositionWithin(new Point(1, 0),
+				Range.of(lowerBound, upperBound));
 		final List<GeoResult<Customer>> expectedGeoResults = new LinkedList<>();
 		expectedGeoResults.add(new GeoResult<>(customer1,
 				new Distance(getDistanceBetweenPoints(new Point(1, 0), new Point(21, 43)) / 1000, Metrics.KILOMETERS)));

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -333,6 +333,27 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void geoJsonFindWithinOrNearTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("---", "", 0);
+		customer1.setPosition(new Point( 2, 45 ));
+		toBeRetrieved.add(customer1);
+		final Customer customer2 = new Customer("+++", "", 0);
+		customer2.setPosition(new Point( 1, 60 ));
+		toBeRetrieved.add(customer2);
+		repository.saveAll(toBeRetrieved);
+		final Customer customer3 = new Customer("---", "", 0);
+		customer3.setPosition(new Point( 180, 0 ));
+		repository.save(customer3);
+		final double distanceInMeters = convertAngleToDistance(30);
+		final Distance distance = new Distance(distanceInMeters / 1000, Metrics.KILOMETERS);
+		final Circle circle = new Circle(new Point(0, 20), distance);
+		final Iterable<Customer> retrieved = repository.findByPositionWithinOrNameAndPositionNear(circle, "+++",
+				new Point(0, 0));
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
 	public void findByLocationWithinBoxTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("", "", 0);

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -311,8 +311,7 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("", "", 0);
 		customer1.setLocation(new int[] { 10, 10 });
-		toBeRetrieved.add(customer1);
-		repository.saveAll(toBeRetrieved);
+		repository.save(customer1);
 		final Customer customer2 = new Customer("", "", 0);
 		customer2.setLocation(new int[] { 0, 0 });
 		repository.save(customer2);
@@ -337,7 +336,45 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		final Customer customer9 = new Customer("", "", 0);
 		customer9.setLocation(new int[] { 20, 20 });
 		repository.save(customer9);
-		final List<Customer> retrieved = repository.findByLocationWithin(new Box(new Point(5, 5), new Point(15, 15)));
+
+		toBeRetrieved.add(customer3);
+		final List<Customer> retrieved = repository.findByLocationWithin(new Box(new Point(9, -1), new Point(11, 1)));
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
+	public void findByGeoJsonPositionWithinBoxTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("", "", 0);
+		customer1.setPosition(new Point( 10, 10 ));
+		repository.save(customer1);
+		final Customer customer2 = new Customer("", "", 0);
+		customer2.setPosition(new Point( 0, 0 ));
+		repository.save(customer2);
+		final Customer customer3 = new Customer("", "", 0);
+		customer3.setPosition(new Point( 10, 0 ));
+		repository.save(customer3);
+		final Customer customer4 = new Customer("", "", 0);
+		customer4.setPosition(new Point( 20, 0 ));
+		repository.save(customer4);
+		final Customer customer5 = new Customer("", "", 0);
+		customer5.setPosition(new Point( 0, 10 ));
+		repository.save(customer5);
+		final Customer customer6 = new Customer("", "", 0);
+		customer6.setPosition(new Point( 20, 10 ));
+		repository.save(customer6);
+		final Customer customer7 = new Customer("", "", 0);
+		customer7.setPosition(new Point( 0, 20 ));
+		repository.save(customer7);
+		final Customer customer8 = new Customer("", "", 0);
+		customer8.setPosition(new Point( 10, 20 ));
+		repository.save(customer8);
+		final Customer customer9 = new Customer("", "", 0);
+		customer9.setPosition(new Point( 20, 20 ));
+		repository.save(customer9);
+
+		toBeRetrieved.add(customer3);
+		final List<Customer> retrieved = repository.findByPositionWithin(new Box(new Point(9, -1), new Point(11, 1)));
 		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -250,6 +250,16 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void findNearGeoJsonTest() {
+		john.setPosition(new Point(2, 2 ));
+		bob.setPosition(new Point( 50, 45 ));
+		repository.saveAll(customers);
+		final Customer[] retrieved = repository.findByPositionNear(new Point(51, 46));
+		final Customer[] check = { bob, john };
+		assertTrue(equals(check, retrieved, cmp, eq, true));
+	}
+
+	@Test
 	public void findWithinTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("", "", 0);

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -732,6 +732,31 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void geoJsonGeoPageTest() {
+		final Customer customer1 = new Customer("", "", 0);
+		customer1.setPosition(new Point ( 0, 2 ));
+		repository.save(customer1);
+		final Customer customer2 = new Customer("", "", 0);
+		customer2.setPosition(new Point ( 0, 3 ));
+		repository.save(customer2);
+		final Customer customer3 = new Customer("", "", 0);
+		customer3.setPosition(new Point ( 0, 4 ));
+		repository.save(customer3);
+		final Customer customer4 = new Customer("", "", 0);
+		customer4.setPosition(new Point ( 0, 6 ));
+		repository.save(customer4);
+		final GeoPage<Customer> retrieved = repository.findByPositionNear(new Point(0.11, 0.11), PageRequest.of(1, 2));
+		final List<GeoResult<Customer>> expectedGeoResults = new LinkedList<>();
+		expectedGeoResults.add(new GeoResult<>(customer3,
+				new Distance(getDistanceBetweenPoints(new Point(0, 0), new Point(0, 4)) / 1000, Metrics.KILOMETERS)));
+		expectedGeoResults.add(new GeoResult<>(customer4,
+				new Distance(getDistanceBetweenPoints(new Point(0, 0), new Point(0, 6)) / 1000, Metrics.KILOMETERS)));
+		assertEquals(4, retrieved.getTotalElements());
+		assertEquals(2, retrieved.getTotalPages());
+		assertTrue(equals(expectedGeoResults, retrieved, geoCmp, geoEq, true));
+	}
+
+	@Test
 	public void buildPredicateWithDistanceTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("+", "", 0);

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -251,8 +251,8 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 
 	@Test
 	public void findNearGeoJsonTest() {
-		john.setPosition(new Point(2, 2 ));
-		bob.setPosition(new Point( 50, 45 ));
+		john.setPosition(new Point(2, 2));
+		bob.setPosition(new Point(45, 50));
 		repository.saveAll(customers);
 		final Customer[] retrieved = repository.findByPositionNear(new Point(51, 46));
 		final Customer[] check = { bob, john };
@@ -594,6 +594,26 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		final Polygon polygon = new Polygon(new Point(0, 0), new Point(30, 60), new Point(50, 0), new Point(30, 10),
 				new Point(30, 20));
 		final List<Customer> retrieved = repository.findByLocationWithin(polygon);
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
+	public void geoJsonPolygonTest() {
+		final int[][] locations = { { 11, 31 }, { 20, 20 }, { 20, 40 }, { 70, 30 }, { 40, 10 }, { -10, -10 },
+				{ -10, 20 }, { -10, 60 }, { 30, 50 }, { 10, 20 }, { 5, 30 } };
+		final Customer[] customers = new Customer[11];
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		for (int i = 0; i < customers.length; ++i) {
+			customers[i] = new Customer("", "", 0);
+			customers[i].setPosition(new Point(locations[i][1], locations[i][0]));
+			repository.save(customers[i]);
+			if (i < 3) {
+				toBeRetrieved.add(customers[i]);
+			}
+		}
+		final Polygon polygon = new Polygon(new Point(0, 0), new Point(30, 60), new Point(50, 0), new Point(30, 10),
+				new Point(30, 20), new Point(0, 0));
+		final List<Customer> retrieved = repository.findByPositionWithin(polygon);
 		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -634,6 +634,23 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void geoJsonGeoResultTest() {
+		final Customer customer1 = new Customer("", "", 0);
+		customer1.setPosition(new Point( 5, 7 ));
+		repository.save(customer1);
+		final Customer customer2 = new Customer("", "", 0);
+		customer2.setPosition(new Point( 50, 70 ));
+		repository.save(customer2);
+		final double distance = convertAngleToDistance(10);
+		final GeoResult<Customer> retrieved = repository.queryByPositionWithin(new Point(1, 2), distance);
+		final double expectedDistanceInMeters = getDistanceBetweenPoints(new Point(5, 7), new Point(1, 2));
+		final double expectedNormalizedDistance = expectedDistanceInMeters / 1000.0
+				/ Metrics.KILOMETERS.getMultiplier();
+		assertEquals(customer1, retrieved.getContent());
+		assertEquals(expectedNormalizedDistance, retrieved.getDistance().getNormalizedValue(), 0.000000001);
+	}
+
+	@Test
 	public void geoResultsTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("", "", 0);

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -244,8 +244,8 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		john.setLocation(new int[] { 2, 2 });
 		bob.setLocation(new int[] { 50, 45 });
 		repository.saveAll(customers);
-		final Customer[] retrieved = repository.findByLocationNear(new Point(10, 20));
-		final Customer[] check = { john, bob };
+		final Customer[] retrieved = repository.findByLocationNear(new Point(51, 46));
+		final Customer[] check = { bob, john };
 		assertTrue(equals(check, retrieved, cmp, eq, true));
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -280,8 +280,34 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 		repository.save(customer5);
 		final Bound<Double> lowerBound = Bound.inclusive(convertAngleToDistance(10));
 		final Bound<Double> upperBound = Bound.inclusive(convertAngleToDistance(50));
-		final List<Customer> retrieved = repository.findByLocationWithinAndName(new Point(0, 0),
-			Range.of(lowerBound, upperBound), "");
+		final List<Customer> retrieved = repository.findByLocationWithinAndName(new Point(0.11, 0.11),
+				Range.of(lowerBound, upperBound), "");
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
+	public void findWithinGeoJsonTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("", "", 0);
+		customer1.setPosition(new Point( 0, 11 ));
+		toBeRetrieved.add(customer1);
+		final Customer customer2 = new Customer("", "", 0);
+		customer2.setPosition(new Point( 10, 10 ));
+		toBeRetrieved.add(customer2);
+		final Customer customer3 = new Customer("", "", 0);
+		customer3.setPosition(new Point( 50, 0 ));
+		toBeRetrieved.add(customer3);
+		repository.saveAll(toBeRetrieved);
+		final Customer customer4 = new Customer("", "", 0);
+		customer4.setPosition(new Point( 0, 0 ));
+		repository.save(customer4);
+		final Customer customer5 = new Customer("---", "", 0);
+		customer5.setPosition(new Point( 10, 10 ));
+		repository.save(customer5);
+		final Bound<Double> lowerBound = Bound.inclusive(convertAngleToDistance(10));
+		final Bound<Double> upperBound = Bound.inclusive(convertAngleToDistance(50));
+		final List<Customer> retrieved = repository.findByPositionWithinAndName(new Point(0.11, 0.11),
+				Range.of(lowerBound, upperBound), "");
 		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -453,6 +453,33 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void geoJsonFindWithinAndWithinTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("+++", "", 0);
+		customer1.setPosition(new Point ( 0, 80 ));
+		toBeRetrieved.add(customer1);
+		final Customer customer2 = new Customer("vvv", "", 0);
+		customer2.setPosition(new Point ( 0, 10 ));
+		toBeRetrieved.add(customer2);
+		repository.saveAll(toBeRetrieved);
+		final Customer customer3 = new Customer("--d", "", 0);
+		customer3.setPosition(new Point ( 0, 19 ));
+		repository.save(customer3);
+		final Customer customer4 = new Customer("--r", "", 0);
+		customer4.setPosition(new Point ( 0, 6 ));
+		repository.save(customer4);
+		final Customer customer5 = new Customer("-!r", "", 0);
+		customer5.setPosition(new Point ( 0, 0 ));
+		repository.save(customer5);
+		final int distance = (int) convertAngleToDistance(11);
+		final Bound<Integer> lowerBound = Bound.inclusive((int) convertAngleToDistance(5));
+		final Bound<Integer> upperBound = Bound.inclusive((int) convertAngleToDistance(15));
+		final Collection<Customer> retrieved = repository.findByPositionWithinAndPositionWithinOrName(new Point(0, 20),
+				distance, new Ring<>(new Point(0, 0), Range.of(lowerBound, upperBound)), "+++");
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
 	public void findByMultipleLocationsAndMultipleRegularFieldsTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();
 		final Customer customer1 = new Customer("John", "", 0);
@@ -491,6 +518,48 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 				.findByNameOrLocationWithinOrNameAndSurnameOrNameAndLocationNearAndSurnameAndLocationWithin("John",
 					new Point(0, 0), distance, "Peter", "Pen", "Jack", new Point(47, 63), "Sparrow", new Point(10, 60),
 					distanceRange);
+		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
+	}
+
+	@Test
+	public void geoJsonFindByMultipleLocationsAndMultipleRegularFieldsTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		final Customer customer1 = new Customer("John", "", 0);
+		customer1.setPosition(new Point ( 0, 89 ));
+		toBeRetrieved.add(customer1);
+		final Customer customer2 = new Customer("Bob", "", 0);
+		customer2.setPosition(new Point ( 5, 0 ));
+		toBeRetrieved.add(customer2);
+		final Customer customer3 = new Customer("Peter", "Pen", 0);
+		customer3.setPosition(new Point ( 89, 0 ));
+		toBeRetrieved.add(customer3);
+		final Customer customer4 = new Customer("Jack", "Sparrow", 0);
+		customer4.setPosition(new Point ( 20, 70 ));
+		toBeRetrieved.add(customer4);
+		repository.saveAll(toBeRetrieved);
+		final Customer customer5 = new Customer("Peter", "The Great", 0);
+		customer5.setPosition(new Point ( 89, 0 ));
+		repository.save(customer5);
+		final Customer customer6 = new Customer("Ballpoint", "Pen", 0);
+		customer6.setPosition(new Point ( 89, 0 ));
+		repository.save(customer6);
+		final Customer customer7 = new Customer("Jack", "Reacher", 0);
+		customer7.setPosition(new Point ( 20, 70 ));
+		repository.save(customer7);
+		final Customer customer8 = new Customer("Jack", "Sparrow", 0);
+		customer8.setPosition(new Point ( 65, 15 ));
+		repository.save(customer8);
+		final Customer customer9 = new Customer("Jack", "Sparrow", 0);
+		customer9.setPosition(new Point ( 75, 25 ));
+		repository.save(customer9);
+		final double distance = convertAngleToDistance(10);
+		final Bound<Double> lowerBound = Bound.inclusive(convertAngleToDistance(10));
+		final Bound<Double> upperBound = Bound.inclusive(convertAngleToDistance(20));
+		final Range<Double> distanceRange = Range.of(lowerBound, upperBound);
+		final List<Customer> retrieved = repository
+				.findByNameOrPositionWithinOrNameAndSurnameOrNameAndPositionNearAndSurnameAndPositionWithin("John",
+						new Point(0, 0), distance, "Peter", "Pen", "Jack", new Point(47, 63), "Sparrow", new Point(10, 60),
+						distanceRange);
 		assertTrue(equals(toBeRetrieved, retrieved, cmp, eq, false));
 	}
 

--- a/src/test/java/com/arangodb/springframework/testdata/Customer.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Customer.java
@@ -30,6 +30,7 @@ import com.arangodb.springframework.annotation.GeoIndexed;
 import com.arangodb.springframework.annotation.Ref;
 import com.arangodb.springframework.annotation.Relations;
 import com.arangodb.springframework.annotation.Rev;
+import org.springframework.data.geo.Point;
 
 /**
  * @author Mark Vollmary
@@ -52,6 +53,8 @@ public class Customer {
 	private boolean alive;
 	@GeoIndexed
 	private int[] location;
+	@GeoIndexed(geoJson = true)
+	private Point position;
 	private Iterable<Integer> integerList;
 	private String[] stringArray;
 	private Iterable<String> stringList;
@@ -188,6 +191,14 @@ public class Customer {
 
 	public void setLocation(final int[] location) {
 		this.location = location;
+	}
+
+	public Point getPosition() {
+		return position;
+	}
+
+	public void setPosition(Point position) {
+		this.position = position;
 	}
 
 	public Iterable<Integer> getIntegerList() {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -11,4 +11,8 @@
   <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <logger name="com.arangodb.internal.velocystream.internal.MessageStore" level="debug" />
+  <logger name="com.arangodb.internal.velocystream.VstCommunicationSync" level="debug" />
+
 </configuration>


### PR DESCRIPTION
This PR adds support to geoJson types (from `com.arangodb.springframework.core.geo`):
- `GeoJsonPoint`
- `GeoJsonMultiPoint`
- `GeoJsonLineString`
- `GeoJsonMultiLineString`
- `GeoJsonPolygon`
- `GeoJsonMultiPolygon`

and to Spring Data geo types (from `org.springframework.data.geo`):
- `Point`
- `Polygon`

All the query derivation capabilities implemented for geospatial points represented as `int[]` have been also implemented for `Point` and `GeoJsonPoint`.

---

fixes https://github.com/arangodb/spring-data-demo/issues/19
