### PR TITLE
bugfix dbname string concatenation in query generation

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -308,10 +308,10 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	@Override
 	public <S extends T> long count(final Example<S> example) {
 		final Map<String, Object> bindVars = new HashMap<>();
+		bindVars.put("@col", getCollectionName());
 		final String predicate = exampleConverter.convertExampleToPredicate(example, bindVars);
 		final String filter = predicate.length() == 0 ? "" : " FILTER " + predicate;
-		final String query = String.format("FOR e IN %s%s COLLECT WITH COUNT INTO length RETURN length",
-				getCollectionName(), filter);
+		final String query = String.format("FOR e IN @@col %s COLLECT WITH COUNT INTO length RETURN length", filter);
 		arangoOperations.collection(domainClass);
 		final ArangoCursor<Long> cursor = arangoOperations.query(query, bindVars, null, Long.class);
 		return cursor.next();
@@ -331,7 +331,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 
 	private <S extends T> ArangoCursor<T> findAllInternal(final Sort sort, @Nullable final Example<S> example,
 			final Map<String, Object> bindVars) {
-		final String query = String.format("FOR e IN %s %s %s RETURN e", getCollectionName(),
+		bindVars.put("@col", getCollectionName());
+		final String query = String.format("FOR e IN @@col %s %s RETURN e",
 				buildFilterClause(example, bindVars), buildSortClause(sort, "e"));
 		arangoOperations.collection(domainClass);
 		return arangoOperations.query(query, bindVars, null, domainClass);
@@ -339,7 +340,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 
 	private <S extends T> ArangoCursor<T> findAllInternal(final Pageable pageable, @Nullable final Example<S> example,
 			final Map<String, Object> bindVars) {
-		final String query = String.format("FOR e IN %s %s %s RETURN e", getCollectionName(),
+		bindVars.put("@col", getCollectionName());
+		final String query = String.format("FOR e IN @@col %s %s RETURN e",
 				buildFilterClause(example, bindVars), buildPageableClause(pageable, "e"));
 		arangoOperations.collection(domainClass);
 		return arangoOperations.query(query, bindVars,

--- a/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
+++ b/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
@@ -100,7 +100,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 
 	@Test
 	public void insertDocumentWithCollName() {
-		final DocumentEntity res = template.insert("customer", new Customer("John", "Doe", 30));
+		final DocumentEntity res = template.insert("test-customer", new Customer("John", "Doe", 30));
 		assertThat(res, is(notNullValue()));
 		assertThat(res.getId(), is(notNullValue()));
 	}
@@ -296,7 +296,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	public void query() {
 		template.insert(new Customer("John", "Doe", 30));
 		final ArangoCursor<Customer> cursor = template.query("FOR c IN @@coll FILTER c.name == @name RETURN c",
-			new MapBuilder().put("@coll", "customer").put("name", "John").get(), new AqlQueryOptions(), Customer.class);
+			new MapBuilder().put("@coll", "test-customer").put("name", "John").get(), new AqlQueryOptions(), Customer.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<Customer> customers = cursor.asListRemaining();
 		assertThat(customers.size(), is(1));
@@ -308,7 +308,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	@Test
 	public void queryWithoutBindParams() {
 		template.insert(new Customer("John", "Doe", 30));
-		final ArangoCursor<Customer> cursor = template.query("FOR c IN customer FILTER c.name == 'John' RETURN c", null,
+		final ArangoCursor<Customer> cursor = template.query("FOR c IN `test-customer` FILTER c.name == 'John' RETURN c", null,
 			new AqlQueryOptions(), Customer.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<Customer> customers = cursor.asListRemaining();
@@ -323,7 +323,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	public void queryMap() {
 		template.insert(new Customer("John", "Doe", 30));
 		final ArangoCursor<Map> cursor = template.query("FOR c IN @@coll FILTER c.name == @name RETURN c",
-			new MapBuilder().put("@coll", "customer").put("name", "John").get(), new AqlQueryOptions(), Map.class);
+			new MapBuilder().put("@coll", "test-customer").put("name", "John").get(), new AqlQueryOptions(), Map.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<Map> customers = cursor.asListRemaining();
 		assertThat(customers.size(), is(1));
@@ -336,7 +336,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	public void queryBaseDocument() {
 		template.insert(new Customer("John", "Doe", 30));
 		final ArangoCursor<BaseDocument> cursor = template.query("FOR c IN @@coll FILTER c.name == @name RETURN c",
-			new MapBuilder().put("@coll", "customer").put("name", "John").get(), new AqlQueryOptions(),
+			new MapBuilder().put("@coll", "test-customer").put("name", "John").get(), new AqlQueryOptions(),
 			BaseDocument.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<BaseDocument> customers = cursor.asListRemaining();
@@ -350,7 +350,7 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 	public void queryVPackSlice() {
 		template.insert(new Customer("John", "Doe", 30));
 		final ArangoCursor<VPackSlice> cursor = template.query("FOR c IN @@coll FILTER c.name == @name RETURN c",
-			new MapBuilder().put("@coll", "customer").put("name", "John").get(), new AqlQueryOptions(),
+			new MapBuilder().put("@coll", "test-customer").put("name", "John").get(), new AqlQueryOptions(),
 			VPackSlice.class);
 		assertThat(cursor, is(notNullValue()));
 		final List<VPackSlice> customers = cursor.asListRemaining();

--- a/src/test/java/com/arangodb/springframework/testdata/Customer.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Customer.java
@@ -36,7 +36,7 @@ import org.springframework.data.geo.Point;
  * @author Mark Vollmary
  *
  */
-@Document
+@Document("test-customer")
 public class Customer {
 
 	@ArangoId

--- a/src/test/java/com/arangodb/springframework/testdata/Product.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Product.java
@@ -28,6 +28,7 @@ import org.springframework.data.annotation.Id;
  *
  */
 @GeoIndex(fields = { "location" })
+@Document("test-product")
 public class Product {
 
 	@Id


### PR DESCRIPTION
Refactored query generation by sending DB names always as bindvar instead of concatenating them in the AQL query. 

---
fixes https://github.com/arangodb/spring-data/issues/225
