### PR TITLE
[Bug][Lombok] canEqual

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.arangodb</groupId>
 	<artifactId>arangodb-spring-data</artifactId>
-	<version>3.7.0</version>
+	<version>3.7.1</version>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>jar</packaging>
 
@@ -47,6 +47,7 @@
 
 	<properties>
 		<java-module-name>com.arangodb.springframework</java-module-name>
+		<gpg.skip>true</gpg.skip>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
 
 	<properties>
 		<java-module-name>com.arangodb.springframework</java-module-name>
-		<gpg.skip>true</gpg.skip>
 	</properties>
 
 	<repositories>

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/AbstractResolver.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/AbstractResolver.java
@@ -144,7 +144,6 @@ public abstract class AbstractResolver<A extends Annotation> {
 			if (method.getName().equals("canEqual")) {
 				return proxyCanEqual(ensureResolved(), args[0]);
 			}
-
 			if (ReflectionUtils.isObjectMethod(method)) {
 				if (ReflectionUtils.isToStringMethod(method)) {
 					return proxyToString();

--- a/src/main/java/com/arangodb/springframework/core/convert/resolver/AbstractResolver.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/resolver/AbstractResolver.java
@@ -141,6 +141,9 @@ public abstract class AbstractResolver<A extends Annotation> {
 			if (GET_REF_ID_METHOD.equals(method)) {
 				return id;
 			}
+			if (method.getName().equals("canEqual")) {
+				return proxyCanEqual(ensureResolved(), args[0]);
+			}
 
 			if (ReflectionUtils.isObjectMethod(method)) {
 				if (ReflectionUtils.isToStringMethod(method)) {
@@ -186,6 +189,10 @@ public abstract class AbstractResolver<A extends Annotation> {
 
 		private int proxyHashCode() {
 			return proxyToString().hashCode();
+		}
+
+		private boolean proxyCanEqual(final Object proxy, final Object obj) {
+			return obj.getClass().isInstance(proxy);
 		}
 
 		private boolean proxyEquals(final Object proxy, final Object obj) {

--- a/src/test/java/com/arangodb/springframework/repository/AbstractArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/AbstractArangoRepositoryTest.java
@@ -8,12 +8,9 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
-import com.arangodb.springframework.repository.query.ShoppingCartRepository;
-import org.junit.Before;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.geo.GeoResult;
-
 import com.arangodb.springframework.AbstractArangoTest;
+import com.arangodb.springframework.repository.query.ProductRepository;
+import com.arangodb.springframework.repository.query.ShoppingCartRepository;
 import com.arangodb.springframework.testdata.Address;
 import com.arangodb.springframework.testdata.Contains;
 import com.arangodb.springframework.testdata.Customer;
@@ -21,6 +18,10 @@ import com.arangodb.springframework.testdata.Material;
 import com.arangodb.springframework.testdata.Owns;
 import com.arangodb.springframework.testdata.Product;
 import com.arangodb.springframework.testdata.ShoppingCart;
+
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.GeoResult;
 
 /**
  * Created by F625633 on 12/07/2017.
@@ -32,6 +33,9 @@ public abstract class AbstractArangoRepositoryTest extends AbstractArangoTest {
 
 	@Autowired
 	protected ShoppingCartRepository shoppingCartRepository;
+	
+	@Autowired
+	protected ProductRepository productRepository;
 
 	protected Customer john;
 	protected Customer bob;

--- a/src/test/java/com/arangodb/springframework/repository/query/ProductRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.arangodb.springframework.repository.query;
+
+import com.arangodb.springframework.repository.ArangoRepository;
+import com.arangodb.springframework.testdata.Product;
+
+public interface ProductRepository extends ArangoRepository<Product, String> {
+}

--- a/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/derived/DerivedQueryCreatorTest.java
@@ -955,6 +955,26 @@ public class DerivedQueryCreatorTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void referenceLazyListCompareTest() {
+		final Customer customer1 = new Customer("Customer1", "Surname1", 0);
+		ShoppingCart cart1 = new ShoppingCart();
+		Product product1 = new Product("asdf1");
+		Product product2 = new Product("asdf2");
+		Product product3 = new Product("asdf3");
+		product1 = productRepository.save(product1);
+		product2 = productRepository.save(product2);
+		product3 = productRepository.save(product3);
+		cart1.setProductsListLazy(Arrays.asList(product1, product2, product3));
+		cart1 = shoppingCartRepository.save(cart1);
+		customer1.setShoppingCart(cart1);
+		repository.save(customer1);
+		final ShoppingCart cartRecoverty = shoppingCartRepository.findById(cart1.getId()).get();
+		final int index = cartRecoverty.getProductsListLazy().indexOf(product2);
+		final boolean result = (index >= 0);
+		assertTrue(result);
+	}
+
+	@Test
 	@Ignore // https://github.com/arangodb/arangodb/issues/5303
 	public void referenceGeospatialTest() {
 		final List<Customer> toBeRetrieved = new LinkedList<>();

--- a/src/test/java/com/arangodb/springframework/testdata/Product.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Product.java
@@ -115,4 +115,29 @@ public class Product {
 		this.nested = nested;
 	}
 
+	/*
+	* Simulating the structure of lombok
+	* https://projectlombok.org/features/EqualsAndHashCode
+	*/
+	@Override public boolean equals(Object o) {
+		if (o == this) return true;
+		if (!(o instanceof Product)) return false;
+		Product other = (Product) o;
+		if (!other.canEqual((Object)this)) return false;
+		if (!this.getId().equals(other.getId())) return false;
+		return true;
+	  }
+	  
+	  @Override public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		result = (result*PRIME) + super.hashCode();
+		result = (result*PRIME) + this.getId().hashCode();
+		return result;
+	  }
+	  
+	  protected boolean canEqual(Object other) {
+		return other instanceof Product;
+	  }
+
 }

--- a/src/test/java/com/arangodb/springframework/testdata/Product.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Product.java
@@ -23,15 +23,19 @@ package com.arangodb.springframework.testdata;
 import com.arangodb.springframework.annotation.*;
 import org.springframework.data.annotation.Id;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * @author Mark Vollmary
  *
  */
 @GeoIndex(fields = { "location" })
 @Document("test-product")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Product {
 
 	@Id
+	@EqualsAndHashCode.Include
 	private String id;
 	@Rev
 	private String rev;
@@ -114,30 +118,5 @@ public class Product {
 	public void setNested(final Product nested) {
 		this.nested = nested;
 	}
-
-	/*
-	* Simulating the structure of lombok
-	* https://projectlombok.org/features/EqualsAndHashCode
-	*/
-	@Override public boolean equals(Object o) {
-		if (o == this) return true;
-		if (!(o instanceof Product)) return false;
-		Product other = (Product) o;
-		if (!other.canEqual((Object)this)) return false;
-		if (!this.getId().equals(other.getId())) return false;
-		return true;
-	  }
-	  
-	  @Override public int hashCode() {
-		final int PRIME = 59;
-		int result = 1;
-		result = (result*PRIME) + super.hashCode();
-		result = (result*PRIME) + this.getId().hashCode();
-		return result;
-	  }
-	  
-	  protected boolean canEqual(Object other) {
-		return other instanceof Product;
-	  }
 
 }

--- a/src/test/java/com/arangodb/springframework/testdata/ShoppingCart.java
+++ b/src/test/java/com/arangodb/springframework/testdata/ShoppingCart.java
@@ -22,6 +22,7 @@ package com.arangodb.springframework.testdata;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.data.annotation.Id;
 
@@ -39,6 +40,10 @@ public class ShoppingCart {
 	private String id;
 	@Ref
 	private Collection<Product> products;
+
+	@Ref(lazy = true)
+	// it needs to be a list
+	private List<Product> productsListLazy;
 
 	public ShoppingCart() {
 		super();
@@ -60,5 +65,19 @@ public class ShoppingCart {
 	public void setProducts(final Collection<Product> products) {
 		this.products = products;
 	}
+
+    /**
+     * @return List<Product> return the productsListLazy
+     */
+    public List<Product> getProductsListLazy() {
+        return productsListLazy;
+    }
+
+    /**
+     * @param productsListLazy the productsListLazy to set
+     */
+    public void setProductsListLazy(List<Product> productsListLazy) {
+        this.productsListLazy = productsListLazy;
+    }
 
 }


### PR DESCRIPTION
Hello gentlemen.

I found a small bug, regarding lombok.

When using some native Java compare function on a list that is using @Ref for a document that is using lombok, Java tries to access the canEqual method.

But lombok puts this method as protected and AbstractResolver cannot call this method.

There is already a form of prevention in AbstractResolver for this scenario, but for other methods. I made the inclusion for this method.

The lombok documentation:
<https://projectlombok.org/features/EqualsAndHashCode>

Thank you for your attention