### PR TITLE
Fix PagingAndSortingRepository fails for Pageable.unpaged()

### DIFF
--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -351,7 +351,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 				buildFilterClause(example, bindVars), buildPageableClause(pageable, "e"));
 		arangoOperations.collection(domainClass);
 		return arangoOperations.query(query, bindVars,
-				pageable != null && pageable.isPaged() ? new AqlQueryOptions().fullCount(true) : null, domainClass);
+				pageable != null ? new AqlQueryOptions().fullCount(true) : null, domainClass);
 	}
 
 	private <S extends T> String buildFilterClause(final Example<S> example, final Map<String, Object> bindVars) {
@@ -366,7 +366,12 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
     private String buildPageableClause(final Pageable pageable, final String varName) {
         if (pageable == null) return "";
         Sort persistentSort = AqlUtils.toPersistentSort(pageable.getSort(), mappingContext, domainClass);
-        Pageable persistentPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), persistentSort);
+		Pageable persistentPageable;
+		if (pageable.isPaged()) {
+			persistentPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), persistentSort);
+		} else {
+			persistentPageable = pageable;
+		}
         return AqlUtils.buildPageableClause(persistentPageable, varName);
     }
 

--- a/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
@@ -13,12 +13,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.domain.*;
 import org.springframework.data.domain.ExampleMatcher.StringMatcher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 
 import com.arangodb.springframework.testdata.Address;
 import com.arangodb.springframework.testdata.Customer;
@@ -513,6 +509,19 @@ public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
 
 		final Customer retrieved = repository.findOne(example).orElse(null);
 		assertEquals(customer, retrieved);
+	}
+
+	@Test
+	public void findAllUnpagedPageableTest() {
+		final List<Customer> toBeRetrieved = new LinkedList<>();
+		toBeRetrieved.add(new Customer("Dhiren", "Upadhyay", 30));
+		toBeRetrieved.add(new Customer("Ashim", "Upadhyay", 28));
+		toBeRetrieved.add(new Customer("Lokendr", "Upadhyay", 24));
+		repository.saveAll(toBeRetrieved);
+		final Page<Customer> retrievedPage = repository.findAll(Pageable.unpaged());
+		assertEquals(toBeRetrieved.size(), retrievedPage.getTotalElements());
+		assertEquals(toBeRetrieved.size(), retrievedPage.getSize());
+		assertEquals(toBeRetrieved, retrievedPage.getContent());
 	}
 
 }


### PR DESCRIPTION
Modify `SimpleArangoRepository#buildPageableClause` for `Pageable.unpaged()` support. In Existing implementation, `Pageable.unpaged()` use case is not handled properly.
