### PR TITLE
Feature: allow embedded entities instead of resolvers

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
@@ -204,7 +204,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 		final String id = source.get(_ID).isString() ? source.get(_ID).getAsString() : null;
 
 		entity.doWithProperties((final ArangoPersistentProperty property) -> {
-			if (!entity.isConstructorArgument(property)) {
+			if (!entity.isCreatorArgument(property)) {
 				final VPackSlice value = source.get(property.getFieldName());
 				readProperty(entity, id, accessor, value, property);
 			}
@@ -212,7 +212,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 
 		entity.doWithAssociations((final Association<ArangoPersistentProperty> association) -> {
 			final ArangoPersistentProperty property = association.getInverse();
-			if (!entity.isConstructorArgument(property)) {
+			if (!entity.isCreatorArgument(property)) {
 				final VPackSlice value = source.get(property.getFieldName());
 				readProperty(entity, id, accessor, value, property);
 			}
@@ -336,9 +336,13 @@ public class DefaultArangoConverter implements ArangoConverter {
 		final ArangoPersistentProperty property,
 		final Annotation annotation) {
 
+		if (source.isNone() || source.isNull()) {
+			return Optional.empty();
+		}
+
 		final Optional<ReferenceResolver<Annotation>> resolver = resolverFactory.getReferenceResolver(annotation);
 
-		if (!resolver.isPresent() || source.isNone()) {
+		if (!resolver.isPresent()) {
 			return Optional.empty();
 		}
 
@@ -351,6 +355,11 @@ public class DefaultArangoConverter implements ArangoConverter {
 			}
 
 			return resolver.map(res -> res.resolveMultiple(ids, property.getTypeInformation(), annotation));
+		}
+
+		else if (source.isObject()) {
+			// source contains target
+			return Optional.of(readInternal(property.getTypeInformation(), source));
 		}
 
 		else {
@@ -370,6 +379,10 @@ public class DefaultArangoConverter implements ArangoConverter {
 		final ArangoPersistentProperty property,
 		final A annotation) {
 
+		if (source.isNull()) {
+			return Optional.empty();
+		}
+
 		final Class<? extends Annotation> collectionType = entity.findAnnotation(Edge.class) != null ? Edge.class
 				: Document.class;
 		final Optional<RelationResolver<Annotation>> resolver = resolverFactory.getRelationResolver(annotation,
@@ -383,6 +396,10 @@ public class DefaultArangoConverter implements ArangoConverter {
 		}
 
 		else if (property.isCollectionLike()) {
+			if (source.isArray()) {
+				// source contains target array
+				return Optional.of(readInternal(property.getTypeInformation(), source));
+			}
 			if (parentId == null) {
 				return Optional.empty();
 			}
@@ -390,7 +407,13 @@ public class DefaultArangoConverter implements ArangoConverter {
 		}
 
 		else if (source.isString()) {
+			// resolve from/to using target id
 			return resolver.map(res -> res.resolveOne(source.getAsString(), property.getTypeInformation(), traversedTypes, annotation));
+		}
+
+		else if (source.isObject()) {
+			// source contains target
+			return Optional.of(readInternal(property.getTypeInformation(), source));
 		}
 
 		else {

--- a/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
+++ b/src/main/java/com/arangodb/springframework/core/convert/DefaultArangoConverter.java
@@ -204,7 +204,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 		final String id = source.get(_ID).isString() ? source.get(_ID).getAsString() : null;
 
 		entity.doWithProperties((final ArangoPersistentProperty property) -> {
-			if (!entity.isCreatorArgument(property)) {
+			if (!entity.isConstructorArgument(property)) {
 				final VPackSlice value = source.get(property.getFieldName());
 				readProperty(entity, id, accessor, value, property);
 			}
@@ -212,7 +212,7 @@ public class DefaultArangoConverter implements ArangoConverter {
 
 		entity.doWithAssociations((final Association<ArangoPersistentProperty> association) -> {
 			final ArangoPersistentProperty property = association.getInverse();
-			if (!entity.isCreatorArgument(property)) {
+			if (!entity.isConstructorArgument(property)) {
 				final VPackSlice value = source.get(property.getFieldName());
 				readProperty(entity, id, accessor, value, property);
 			}

--- a/src/main/java/com/arangodb/springframework/core/mapping/ArangoPersistentProperty.java
+++ b/src/main/java/com/arangodb/springframework/core/mapping/ArangoPersistentProperty.java
@@ -22,6 +22,7 @@ package com.arangodb.springframework.core.mapping;
 
 import java.util.Optional;
 
+import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 
 import com.arangodb.springframework.annotation.From;
@@ -42,6 +43,9 @@ import com.arangodb.springframework.annotation.TtlIndexed;
 public interface ArangoPersistentProperty extends PersistentProperty<ArangoPersistentProperty> {
 
 	String getFieldName();
+
+	@Override
+	ArangoPersistentEntity<?> getOwner();
 
 	boolean isArangoIdProperty();
 

--- a/src/main/java/com/arangodb/springframework/core/mapping/DefaultArangoPersistentProperty.java
+++ b/src/main/java/com/arangodb/springframework/core/mapping/DefaultArangoPersistentProperty.java
@@ -22,6 +22,7 @@ package com.arangodb.springframework.core.mapping;
 
 import java.util.Optional;
 
+import com.arangodb.entity.CollectionType;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
@@ -55,11 +56,16 @@ public class DefaultArangoPersistentProperty extends AnnotationBasedPersistentPr
 	private final FieldNamingStrategy fieldNamingStrategy;
 
 	public DefaultArangoPersistentProperty(final Property property,
-		final PersistentEntity<?, ArangoPersistentProperty> owner, final SimpleTypeHolder simpleTypeHolder,
+		final ArangoPersistentEntity<?> owner, final SimpleTypeHolder simpleTypeHolder,
 		final FieldNamingStrategy fieldNamingStrategy) {
 		super(property, owner, simpleTypeHolder);
 		this.fieldNamingStrategy = fieldNamingStrategy != null ? fieldNamingStrategy
 				: PropertyNameFieldNamingStrategy.INSTANCE;
+	}
+
+	@Override
+	public ArangoPersistentEntity<?> getOwner() {
+		return (ArangoPersistentEntity<?>) super.getOwner();
 	}
 
 	@Override
@@ -106,9 +112,9 @@ public class DefaultArangoPersistentProperty extends AnnotationBasedPersistentPr
 			fieldName = "_key";
 		} else if (isRevProperty()) {
 			fieldName = "_rev";
-		} else if (getFrom().isPresent()) {
+		} else if (getFrom().isPresent() && getOwner().getCollectionOptions().getType() == CollectionType.EDGES) {
 			fieldName = "_from";
-		} else if (getTo().isPresent()) {
+		} else if (getTo().isPresent() && getOwner().getCollectionOptions().getType() == CollectionType.EDGES) {
 			fieldName = "_to";
 		} else {
 			fieldName = getAnnotatedFieldName().orElse(fieldNamingStrategy.getFieldName(this));

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -37,249 +37,266 @@ import com.arangodb.springframework.testdata.CustomerNameProjection;
  */
 public interface CustomerRepository extends ArangoRepository<Customer, String>, ImportedQueryRepository{
 
-	@Query("FOR c IN #{#collection} FILTER #{filterGenerator.allEqual('c', #kv)} RETURN c")
-	List<Customer> findByAllEqual(@SpelParam("kv") Map<String, Object> kv);
+    @Query("FOR c IN #{#collection} FILTER #{filterGenerator.allEqual('c', #kv)} RETURN c")
+    List<Customer> findByAllEqual(@SpelParam("kv") Map<String, Object> kv);
 
-	@Query("FOR c IN #collection FILTER c._key == @id RETURN c")
-	Map<String, Object> findOneByIdAqlWithNamedParameter(@Param("id") String idString, AqlQueryOptions options);
+    @Query("FOR c IN #collection FILTER c._key == @id RETURN c")
+    Map<String, Object> findOneByIdAqlWithNamedParameter(@Param("id") String idString, AqlQueryOptions options);
 
-	@Query("FOR c IN #collection FILTER c.`customer-name` == @name AND c._key == @id RETURN c")
-	@QueryOptions(cache = true, ttl = 128)
-	BaseDocument findOneByIdAndNameAql(@Param("id") String id, @Param("name") String name);
+    @Query("FOR c IN #collection FILTER c.`customer-name` == @name AND c._key == @id RETURN c")
+    @QueryOptions(cache = true, ttl = 128)
+    BaseDocument findOneByIdAndNameAql(@Param("id") String id, @Param("name") String name);
 
-	@QueryOptions(maxPlans = 1000, ttl = 128)
-	@Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
-	ArangoCursor<Customer> findOneByBindVarsAql(AqlQueryOptions options, @BindVars Map<String, Object> bindVars);
+    @QueryOptions(maxPlans = 1000, ttl = 128)
+    @Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
+    ArangoCursor<Customer> findOneByBindVarsAql(AqlQueryOptions options, @BindVars Map<String, Object> bindVars);
 
-	@Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
-	Customer findOneByNameAndBindVarsAql(@Param("name") String name, @BindVars Map<String, Object> bindVars);
+    @Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
+    Customer findOneByNameAndBindVarsAql(@Param("name") String name, @BindVars Map<String, Object> bindVars);
 
-	@Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
-	Customer findOneByIdAndNameWithBindVarsAql(@Param("name") String name, @BindVars Map<String, Object> bindVars);
+    @Query("FOR c IN #collection FILTER c._key == @id AND c.`customer-name` == @name RETURN c")
+    Customer findOneByIdAndNameWithBindVarsAql(@Param("name") String name, @BindVars Map<String, Object> bindVars);
 
-	@Query("FOR c IN @@0 FILTER \"@1\" != '@2' AND c._id == @1 RETURN c")
-	Customer findOneByIdInCollectionAqlWithUnusedParam(String collection, String id, String id2);
+    @Query("FOR c IN @@0 FILTER \"@1\" != '@2' AND c._id == @1 RETURN c")
+    Customer findOneByIdInCollectionAqlWithUnusedParam(String collection, String id, String id2);
 
-	@Query("FOR c IN @@collection FILTER \"\\\"@id\\\"\" != '\"@id2\"' AND c._id == @id RETURN c")
-	Customer findOneByIdInNamedCollectionAqlWithUnusedParam(
-		@Param("@collection") String collection,
-		@Param("id") String id,
-		@Param("id2") String id2);
+    @Query("FOR c IN @@collection FILTER \"\\\"@id\\\"\" != '\"@id2\"' AND c._id == @id RETURN c")
+    Customer findOneByIdInNamedCollectionAqlWithUnusedParam(
+            @Param("@collection") String collection,
+            @Param("id") String id,
+            @Param("id2") String id2);
 
-	@Query("FOR c IN @@collection FILTER \"'@id'\" != '\\'@id2\\'' AND c._id == @id RETURN c")
-	Customer findOneByIdInIncorrectNamedCollectionAql(
-		@Param("collection") String collection,
-		@Param("id") String id,
-		@Param("id2") String id2);
+    @Query("FOR c IN @@collection FILTER \"'@id'\" != '\\'@id2\\'' AND c._id == @id RETURN c")
+    Customer findOneByIdInIncorrectNamedCollectionAql(
+            @Param("collection") String collection,
+            @Param("id") String id,
+            @Param("id2") String id2);
 
-	@Query("FOR c IN @collection FILTER c._id == @id RETURN c")
-	Customer findOneByIdInNamedCollectionAqlRejected(@Param("collection") String collection, @Param("id") String id);
+    @Query("FOR c IN @collection FILTER c._id == @id RETURN c")
+    Customer findOneByIdInNamedCollectionAqlRejected(@Param("collection") String collection, @Param("id") String id);
 
-	@Query("FOR c in #collection FILTER c.surname == @surname RETURN c")
-	List<Customer> findManyBySurname(@Param("surname") String surname);
+    @Query("FOR c in #collection FILTER c.surname == @surname RETURN c")
+    List<Customer> findManyBySurname(@Param("surname") String surname);
 
-	Set<Customer> findDistinctByNameAfter(String name);
+    Set<Customer> findDistinctByNameAfter(String name);
 
-	List<Customer> findByNameNotIgnoreCaseAndAgeLessThanIgnoreCaseOrderByNameDesc(String name, int age);
+    List<Customer> findByNameNotIgnoreCaseAndAgeLessThanIgnoreCaseOrderByNameDesc(String name, int age);
 
-	Iterable<Customer> findTop3ByAgeInAndStringArrayIgnoreCaseOrNameNotInAndIntegerListIgnoreCaseOrderByAgeAscNameDescAllIgnoreCase(
-		int[] ages,
-		String[] stringArray,
-		String[] names,
-		List<Integer> integerList);
+    Iterable<Customer> findTop3ByAgeInAndStringArrayIgnoreCaseOrNameNotInAndIntegerListIgnoreCaseOrderByAgeAscNameDescAllIgnoreCase(
+            int[] ages,
+            String[] stringArray,
+            String[] names,
+            List<Integer> integerList);
 
-	Customer[] findDistinctByAgeGreaterThanEqualOrStringArrayAndNameBeforeOrIntegerListOrderByNameAscAgeAscAllIgnoreCase(
-		int age,
-		String[] stringArray,
-		String name,
-		List<Integer> integerList);
+    Customer[] findDistinctByAgeGreaterThanEqualOrStringArrayAndNameBeforeOrIntegerListOrderByNameAscAgeAscAllIgnoreCase(
+            int age,
+            String[] stringArray,
+            String name,
+            List<Integer> integerList);
 
-	Collection<Customer> findTop2DistinctByStringArrayContainingIgnoreCaseOrIntegerListNotNullIgnoreCaseOrderByNameAsc(
-		String string);
+    Collection<Customer> findTop2DistinctByStringArrayContainingIgnoreCaseOrIntegerListNotNullIgnoreCaseOrderByNameAsc(
+            String string);
 
-	Collection<Customer> findByStringArrayNotContainingIgnoreCase(String string);
+    Collection<Customer> findByStringArrayNotContainingIgnoreCase(String string);
 
-	Collection<Customer> findByNameContaining(String string);
+    Collection<Customer> findByNameContaining(String string);
 
-	Collection<Customer> findByNameContainingIgnoreCase(String string);
+    Collection<Customer> findByNameContainingIgnoreCase(String string);
 
-	int countByAgeGreaterThanOrStringArrayNullAndIntegerList(int age, List<Integer> integerList);
+    int countByAgeGreaterThanOrStringArrayNullAndIntegerList(int age, List<Integer> integerList);
 
-	Integer countDistinctByAliveTrueOrNameLikeOrAgeLessThanEqual(String pattern, int age);
+    Integer countDistinctByAliveTrueOrNameLikeOrAgeLessThanEqual(String pattern, int age);
 
-	Customer findByNameStartsWithAndSurnameEndsWithAndAgeBetween(
-		String prefix,
-		String suffix,
-		int lowerBound,
-		int upperBound);
+    Customer findByNameStartsWithAndSurnameEndsWithAndAgeBetween(
+            String prefix,
+            String suffix,
+            int lowerBound,
+            int upperBound);
 
-	void removeByNameNotLikeAndSurnameRegexOrAliveFalse(String pattern, String regex);
+    void removeByNameNotLikeAndSurnameRegexOrAliveFalse(String pattern, String regex);
 
-	// GEOSPATIAL
+    // GEOSPATIAL
 
-	Customer[] findByLocationNear(Point location);
+    Customer[] findByLocationNear(Point location);
 
-	Customer[] findByPositionNear(Point location);
+    Customer[] findByPositionNear(Point location);
 
-	List<Customer> findByLocationWithinAndName(Point location, Range<Double> distanceRange, String name);
+    List<Customer> findByLocationWithinAndName(Point location, Range<Double> distanceRange, String name);
 
-	List<Customer> findByPositionWithinAndName(Point location, Range<Double> distanceRange, String name);
+    List<Customer> findByPositionWithinAndName(Point location, Range<Double> distanceRange, String name);
 
-	Iterable<Customer> findByLocationWithinOrNameAndLocationNear(Circle circle, String name, Point location2);
+    Iterable<Customer> findByLocationWithinOrNameAndLocationNear(Circle circle, String name, Point location2);
 
-	Iterable<Customer> findByPositionWithinOrNameAndPositionNear(Circle circle, String name, Point location2);
+    Iterable<Customer> findByPositionWithinOrNameAndPositionNear(Circle circle, String name, Point location2);
 
-	List<Customer> findByLocationWithin(Box box);
+    List<Customer> findByLocationWithin(Box box);
 
-	List<Customer> findByPositionWithin(Box box);
+    List<Customer> findByPositionWithin(Box box);
 
-	Collection<Customer> findByLocationWithinAndLocationWithinOrName(
-			Point location,
-			int distance,
-			Ring<?> ring,
-			String name);
+    Collection<Customer> findByLocationWithinAndLocationWithinOrName(
+            Point location,
+            int distance,
+            Ring<?> ring,
+            String name);
 
-	Collection<Customer> findByPositionWithinAndPositionWithinOrName(
-			Point location,
-			int distance,
-			Ring<?> ring,
-			String name);
+    Collection<Customer> findByPositionWithinAndPositionWithinOrName(
+            Point location,
+            int distance,
+            Ring<?> ring,
+            String name);
 
-	List<Customer> findByLocationWithin(Polygon polygon);
+    List<Customer> findByLocationWithin(Polygon polygon);
 
-	List<Customer> findByPositionWithin(Polygon polygon);
+    List<Customer> findByPositionWithin(Polygon polygon);
 
-	List<Customer> findByNameOrLocationWithinOrNameAndSurnameOrNameAndLocationNearAndSurnameAndLocationWithin(
-			String name1,
-			Point location1,
-			double distance,
-			String name2,
-			String surname1,
-			String name3,
-			Point location2,
-			String surname2,
-			Point location3,
-			Range<Double> distanceRange);
+    List<Customer> findByNameOrLocationWithinOrNameAndSurnameOrNameAndLocationNearAndSurnameAndLocationWithin(
+            String name1,
+            Point location1,
+            double distance,
+            String name2,
+            String surname1,
+            String name3,
+            Point location2,
+            String surname2,
+            Point location3,
+            Range<Double> distanceRange);
 
-	List<Customer> findByNameOrPositionWithinOrNameAndSurnameOrNameAndPositionNearAndSurnameAndPositionWithin(
-			String name1,
-			Point location1,
-			double distance,
-			String name2,
-			String surname1,
-			String name3,
-			Point location2,
-			String surname2,
-			Point location3,
-			Range<Double> distanceRange);
+    List<Customer> findByNameOrPositionWithinOrNameAndSurnameOrNameAndPositionNearAndSurnameAndPositionWithin(
+            String name1,
+            Point location1,
+            double distance,
+            String name2,
+            String surname1,
+            String name3,
+            Point location2,
+            String surname2,
+            Point location3,
+            Range<Double> distanceRange);
 
-	// EXISTS
+    // EXISTS
 
-	boolean existsByName(String name);
+    boolean existsByName(String name);
 
-	Customer[] findByNestedCustomerAliveExistsAndStringListAllIgnoreCase(List<String> stringList);
+    Customer[] findByNestedCustomerAliveExistsAndStringListAllIgnoreCase(List<String> stringList);
 
-	// SORT
+    // SORT
 
-	Customer[] findByNameOrderBySurnameAsc(Sort sort, String name);
+    Customer[] findByNameOrderBySurnameAsc(Sort sort, String name);
 
-	@Query("FOR c IN #collection FILTER c.`customer-name` == @name #sort RETURN c")
-	List<Customer> findByNameWithSort(Sort sort, @Param("name") String name);
+    @Query("FOR c IN #collection FILTER c.`customer-name` == @name #sort RETURN c")
+    List<Customer> findByNameWithSort(Sort sort, @Param("name") String name);
 
-	// PAGEABLE
+    // PAGEABLE
 
-	Page<Customer> readByNameAndSurname(Pageable pageable, String name, AqlQueryOptions options, String surname);
+    Page<Customer> readByNameAndSurname(Pageable pageable, String name, AqlQueryOptions options, String surname);
 
-	@Query("FOR c IN #collection FILTER c.`customer-name` == @name AND c.surname == @surname #pageable RETURN c")
-	Page<Customer> findByNameAndSurnameWithPageable(Pageable pageable, @Param("name") String name, @Param("surname") String surname);
+    @Query("FOR c IN #collection FILTER c.`customer-name` == @name AND c.surname == @surname #pageable RETURN c")
+    Page<Customer> findByNameAndSurnameWithPageable(Pageable pageable, @Param("name") String name, @Param("surname") String surname);
 
-	// GEO_RESULT, GEO_RESULTS, GEO_PAGE
+    // GEO_RESULT, GEO_RESULTS, GEO_PAGE
 
-	GeoResult<Customer> queryByLocationWithin(Point location, double distance);
+    GeoResult<Customer> queryByLocationWithin(Point location, double distance);
 
-	GeoResult<Customer> queryByPositionWithin(Point location, double distance);
+    GeoResult<Customer> queryByPositionWithin(Point location, double distance);
 
-	GeoResults<Customer> findByLocationWithin(Point location, Range<Double> distanceRange);
+    GeoResults<Customer> findByLocationWithin(Point location, Range<Double> distanceRange);
 
-	GeoResults<Customer> findByPositionWithin(Point location, Range<Double> distanceRange);
+    GeoResults<Customer> findByPositionWithin(Point location, Range<Double> distanceRange);
 
-	GeoPage<Customer> findByLocationNear(Point location, Pageable pageable);
+    GeoPage<Customer> findByLocationNear(Point location, Pageable pageable);
 
-	GeoPage<Customer> findByPositionNear(Point location, Pageable pageable);
+    GeoPage<Customer> findByPositionNear(Point location, Pageable pageable);
 
-	GeoResults<Customer> findByNameOrSurnameAndLocationWithinOrLocationWithin(
-			String name,
-			String surname,
-			Point location1,
-			Distance distance,
-			Point location2,
-			Range<Distance> distanceRange);
+    GeoResults<Customer> findByNameOrSurnameAndLocationWithinOrLocationWithin(
+            String name,
+            String surname,
+            Point location1,
+            Distance distance,
+            Point location2,
+            Range<Distance> distanceRange);
 
-	GeoResults<Customer> findByNameOrSurnameAndPositionWithinOrPositionWithin(
-			String name,
-			String surname,
-			Point location1,
-			Distance distance,
-			Point location2,
-			Range<Distance> distanceRange);
+    GeoResults<Customer> findByNameOrSurnameAndPositionWithinOrPositionWithin(
+            String name,
+            String surname,
+            Point location1,
+            Distance distance,
+            Point location2,
+            Range<Distance> distanceRange);
 
-	// NESTED PROPERTIES
+    // NESTED PROPERTIES
 
-	List<Customer> findByNestedCustomerName(String name);
+    List<Customer> findByNestedCustomerName(String name);
 
-	List<Customer> findByNicknameValue(String value);
+    List<Customer> findByNicknameValue(String value);
 
-	// REFERENCES
+    // REFERENCES
 
-	List<Customer> findByNestedCustomersNestedCustomerShoppingCartProductsLocationWithin(
-		Point location,
-		double distance);
+    List<Customer> findByNestedCustomersNestedCustomerShoppingCartProductsLocationWithin(
+            Point location,
+            double distance);
 
-	List<Customer> findByNestedCustomersNestedCustomerShoppingCartProductsNameLike(String name);
+    List<Customer> findByNestedCustomersNestedCustomerShoppingCartProductsNameLike(String name);
 
-	// Graph traversal
+    // Graph traversal
 
-	List<Customer> getByOwnsName(String name);
+    List<Customer> getByOwnsName(String name);
 
-	List<Customer> getByOwnsContainsName(String name);
+    List<Customer> getByOwnsContainsName(String name);
 
-	List<Customer> getByOwnsNameAndOwns2Name(String name, String name2);
+    List<Customer> getByOwnsNameAndOwns2Name(String name, String name2);
 
-	// Count query
+    // Count query
 
-	@Query("RETURN COUNT(@@collection)")
-	long queryCount(@Param("@collection") Class<Customer> collection);
+    @Query("RETURN COUNT(@@collection)")
+    long queryCount(@Param("@collection") Class<Customer> collection);
 
-	// Date query
+    // Date query
 
-	@Query("RETURN DATE_ISO8601(1474988621)")
-	Instant queryDate();
+    @Query("RETURN DATE_ISO8601(1474988621)")
+    Instant queryDate();
 
-	// Named query
+    // Named query
 
-	Customer findOneByIdNamedQuery(@Param("id") String id);
+    Customer findOneByIdNamedQuery(@Param("id") String id);
 
-	@Query("WITH #collection, `test-product` " +
-			"FOR c IN #collection FILTER c._key == @id " +
-			"LET owns = FIRST(FOR p IN OUTBOUND c owns RETURN p) " +
-			"LIMIT 1 " +
-			"RETURN MERGE(c, { owns: owns, owns2: owns})")
-	Optional<Customer> findByIdUsingEmbeddedEntities(@Param("id") String id);
+    @Query( "WITH #collection, `test-product` " +
+            "FOR c IN #collection FILTER c._key == @id " +
+            "LET owns = (" +
+            "	FOR p IN OUTBOUND c owns " +
+            "	LET contains = FIRST(FOR m IN OUTBOUND p contains RETURN m) " +
+            "	RETURN MERGE(p, { contains: contains })" +
+            ") " +
+            "RETURN MERGE(c, { owns: owns, owns2: owns})")
+    Optional<Customer> findByIdUsingEmbeddedEntities(@Param("id") String id);
 
-	// Static projection
+    @Query( "WITH #collection, `test-product` " +
+            "FOR c IN #collection FILTER c._key == @id " +
+            "RETURN MERGE(c, { owns: [], owns2: [] })")
+    Optional<Customer> embeddedEntitiesEmptyArray(@Param("id") String id);
 
-	@Query("FOR c IN #collection FILTER c._key == @id RETURN c")
-	CustomerNameProjection findOneByIdWithStaticProjection(@Param("id") String id);
+    @Query( "WITH #collection, `test-product` " +
+            "FOR c IN #collection FILTER c._key == @id " +
+            "LET owns = (" +
+            "	FOR p IN OUTBOUND c owns " +
+            "	RETURN MERGE(p, { contains: null })" +
+            ") " +
+            "RETURN MERGE(c, { owns: owns, owns2: owns})")
+    Optional<Customer> embeddedEntitiesNull(@Param("id") String id);
 
-	@Query("FOR c IN #collection FILTER c.age >= 18 RETURN c")
-	List<CustomerNameProjection> findManyLegalAgeWithStaticProjection();
+    // Static projection
 
-	// Dynamic projection
+    @Query("FOR c IN #collection FILTER c._key == @id RETURN c")
+    CustomerNameProjection findOneByIdWithStaticProjection(@Param("id") String id);
 
-	@Query("FOR c IN #collection FILTER c._key == @id RETURN c")
-	<T> T findOneByIdWithDynamicProjection(@Param("id") String id, Class<T> projection);
+    @Query("FOR c IN #collection FILTER c.age >= 18 RETURN c")
+    List<CustomerNameProjection> findManyLegalAgeWithStaticProjection();
 
-	@Query("FOR c IN #collection FILTER c.age >= 18 RETURN c")
-	<T> List<T> findManyLegalAgeWithDynamicProjection(Class<T> projection);
+    // Dynamic projection
+
+    @Query("FOR c IN #collection FILTER c._key == @id RETURN c")
+    <T> T findOneByIdWithDynamicProjection(@Param("id") String id, Class<T> projection);
+
+    @Query("FOR c IN #collection FILTER c.age >= 18 RETURN c")
+    <T> List<T> findManyLegalAgeWithDynamicProjection(Class<T> projection);
 
 }

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -1,10 +1,7 @@
 package com.arangodb.springframework.repository;
 
 import java.time.Instant;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.arangodb.springframework.annotation.SpelParam;
 import org.springframework.data.domain.Page;
@@ -261,6 +258,13 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 	// Named query
 
 	Customer findOneByIdNamedQuery(@Param("id") String id);
+
+	@Query("WITH #collection, `test-product` " +
+			"FOR c IN #collection FILTER c._key == @id " +
+			"LET owns = FIRST(FOR p IN OUTBOUND c owns RETURN p) " +
+			"LIMIT 1 " +
+			"RETURN MERGE(c, { owns: owns, owns2: owns})")
+	Optional<Customer> findByIdUsingEmbeddedEntities(@Param("id") String id);
 
 	// Static projection
 

--- a/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/CustomerRepository.java
@@ -259,7 +259,7 @@ public interface CustomerRepository extends ArangoRepository<Customer, String>, 
 
     Customer findOneByIdNamedQuery(@Param("id") String id);
 
-    @Query( "WITH #collection, `test-product` " +
+    @Query( "WITH #collection, `test-product`, `material` " +
             "FOR c IN #collection FILTER c._key == @id " +
             "LET owns = (" +
             "	FOR p IN OUTBOUND c owns " +

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -8,12 +8,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import com.arangodb.springframework.testdata.Owns;
+import com.arangodb.springframework.testdata.Product;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -271,4 +270,18 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		assertThat(customers.next(), is(nullValue()));
 	}
 
+	@Test
+	public void findOneUsingEmbeddedEntities() {
+		Customer owner = new Customer("A", "C", 4);
+		template.insert(owner);
+		Product pa = new Product("a");
+		Product pb = new Product("b");
+		template.insert(Arrays.asList(pa, pb), Product.class);
+		template.insert(new Owns(owner, pa));
+		template.insert(new Owns(owner, pb));
+
+		Customer actual = repository.findByIdUsingEmbeddedEntities(owner.getId()).get();
+		assertThat(actual.getOwns(), containsInAnyOrder(pa, pb));
+		assertThat(actual.getOwns2(), is(actual.getOwns()));
+	}
 }

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -9,9 +9,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
-import com.arangodb.springframework.testdata.Owns;
-import com.arangodb.springframework.testdata.Product;
+import com.arangodb.springframework.testdata.*;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -26,8 +26,6 @@ import com.arangodb.entity.BaseDocument;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.repository.AbstractArangoRepositoryTest;
 import com.arangodb.springframework.repository.OverriddenCrudMethodsRepository;
-import com.arangodb.springframework.testdata.Customer;
-import com.arangodb.springframework.testdata.CustomerNameProjection;
 
 /**
  *
@@ -271,16 +269,53 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 
 	@Test
 	public void findOneUsingEmbeddedEntities() {
-		Customer owner = new Customer("A", "C", 4);
-		template.insert(owner);
+		Material wood = new Material("wood");
+		Material glass = new Material("glass");
+		template.insert(wood);
+		template.insert(glass);
+
 		Product pa = new Product("a");
 		Product pb = new Product("b");
 		template.insert(Arrays.asList(pa, pb), Product.class);
+		template.insert(new Contains(pa, wood));
+		template.insert(new Contains(pb, glass));
+
+		Customer owner = new Customer("A", "C", 4);
+		template.insert(owner);
 		template.insert(new Owns(owner, pa));
 		template.insert(new Owns(owner, pb));
 
 		Customer actual = repository.findByIdUsingEmbeddedEntities(owner.getId()).get();
 		assertThat(actual.getOwns(), containsInAnyOrder(pa, pb));
 		assertThat(actual.getOwns2(), is(actual.getOwns()));
+
+		List<Material> materials = actual.getOwns().stream().map(Product::getContains).collect(Collectors.toList());
+		assertThat(materials, hasItems(wood, glass));
 	}
+
+	@Test
+	public void embeddedEntitiesNull() {
+		Product pa = new Product("a");
+		Product pb = new Product("b");
+		template.insert(Arrays.asList(pa, pb), Product.class);
+
+		Customer owner = new Customer("A", "C", 4);
+		template.insert(owner);
+		template.insert(new Owns(owner, pa));
+		template.insert(new Owns(owner, pb));
+
+		Customer actual = repository.embeddedEntitiesNull(owner.getId()).get();
+		assertThat(actual.getOwns(), containsInAnyOrder(pa, pb));
+		assertThat(actual.getOwns2(), is(actual.getOwns()));
+	}
+
+	@Test
+	public void embeddedEntitiesEmptyArray() {
+		Customer owner = new Customer("A", "C", 4);
+		template.insert(owner);
+
+		Customer actual = repository.embeddedEntitiesEmptyArray(owner.getId()).get();
+		assertThat(actual.getOwns().size(), is(0));
+	}
+
 }

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -12,7 +12,6 @@ import java.util.*;
 
 import com.arangodb.springframework.testdata.Owns;
 import com.arangodb.springframework.testdata.Product;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;

--- a/src/test/java/com/arangodb/springframework/testdata/Material.java
+++ b/src/test/java/com/arangodb/springframework/testdata/Material.java
@@ -4,6 +4,8 @@ import org.springframework.data.annotation.Id;
 
 import com.arangodb.springframework.annotation.Rev;
 
+import java.util.Objects;
+
 /**
  * Created by markmccormick on 24/08/2017.
  */
@@ -25,5 +27,18 @@ public class Material {
 
 	public void setName(final String name) {
 		this.name = name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Material material = (Material) o;
+		return Objects.equals(id, material.id) && Objects.equals(rev, material.rev) && Objects.equals(name, material.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, rev, name);
 	}
 }


### PR DESCRIPTION
As described in #269 this is an option to tune performance of fetching referenced entities.

* adjusted the `DefaultArangoConverter` to recognise full entity data in the source which will be read directly instead of using a resolver
* fixed a field naming problem when a document has a property annotated by `@From` or `@To` (including a small refactoring to expose the more specific owner on `ArangoPersistentProperty`)