### PR TITLE
[DE-682] #281 better exception translation

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -64,6 +64,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.expression.BeanFactoryAccessor;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.expression.Expression;
@@ -148,10 +149,6 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			}
 			return db;
 		});
-	}
-
-	private DataAccessException translateExceptionIfPossible(final RuntimeException exception) {
-		return exceptionTranslator.translateExceptionIfPossible(exception);
 	}
 
 	private ArangoCollection _collection(final String name) {
@@ -299,7 +296,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			}
 			return version;
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -353,7 +350,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(entityClass).deleteDocuments(toJsonNodeCollection(values), options, entityClass);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		potentiallyEmitAfterDeleteEvent(values, entityClass, result);
@@ -376,7 +373,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(entityClass, id).deleteDocument(determineDocumentKeyFromId(id), options, entityClass);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		potentiallyEmitEvent(new AfterDeleteEvent<>(id, entityClass));
@@ -398,7 +395,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(entityClass).updateDocuments(toJsonNodeCollection(values), options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(values, result);
@@ -423,7 +420,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			result = _collection(value.getClass(), id).updateDocument(determineDocumentKeyFromId(id), toJsonNode(value),
 					options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(value, result);
@@ -446,7 +443,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(entityClass).replaceDocuments(toJsonNodeCollection(values), options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(values, result);
@@ -470,7 +467,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			result = _collection(value.getClass(), id).replaceDocument(determineDocumentKeyFromId(id), toJsonNode(value),
 					options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(value, result);
@@ -491,7 +488,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 					JsonNode.class, options);
 			return Optional.ofNullable(fromJsonNode(entityClass, doc));
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -516,7 +513,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			final MultiDocumentEntity<JsonNode> docs = _collection(entityClass).getDocuments(keys, JsonNode.class);
 			return docs.getDocuments().stream().map(doc -> fromJsonNode(entityClass, doc)).collect(Collectors.toList());
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -530,7 +527,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(entityClass).insertDocuments(toJsonNodeCollection(values), options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(values, result);
@@ -552,7 +549,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(value.getClass()).insertDocument(toJsonNode(value), options);
 		} catch (final ArangoDBException e) {
-			throw exceptionTranslator.translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(value, result);
@@ -574,7 +571,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			result = _collection(collectionName).insertDocument(toJsonNode(value), options);
 		} catch (final ArangoDBException e) {
-			throw exceptionTranslator.translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFields(value, result);
@@ -607,7 +604,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			);
 			result = it.hasNext() ? it.next() : null;
 		} catch (final ArangoDBException e) {
-			throw exceptionTranslator.translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFieldsFromObject(value, result);
@@ -635,7 +632,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 					entityClass
 			).asListRemaining();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 
 		updateDBFieldsFromObjects(values, result);
@@ -715,7 +712,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			return _collection(entityClass).documentExists(determineDocumentKeyFromId(id));
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -725,7 +722,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			db.drop();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 		databaseCache.remove(db.name());
 		collectionCache.keySet().stream().filter(key -> key.getDb().equals(db.name()))
@@ -762,7 +759,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 		try {
 			return arango.getUsers();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -324,7 +324,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
 			ArangoCursor<JsonNode> cursor = db().query(query, JsonNode.class, bindVars == null ? null : prepareBindVars(bindVars), options);
 			return new ArangoExtCursor<>(cursor, entityClass, converter, eventPublisher);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/template/DefaultCollectionOperations.java
+++ b/src/main/java/com/arangodb/springframework/core/template/DefaultCollectionOperations.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 
 import com.arangodb.ArangoCollection;
@@ -55,10 +56,6 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		this.exceptionTranslator = exceptionTranslator;
 	}
 
-	private DataAccessException translateExceptionIfPossible(final RuntimeException exception) {
-		return exceptionTranslator.translateExceptionIfPossible(exception);
-	}
-
 	@Override
 	public String name() {
 		return collection.name();
@@ -70,7 +67,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			collection.drop();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -79,7 +76,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			collection.truncate();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -89,7 +86,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 			final Long count = collection.count().getCount();
 			return count != null ? count : -1L;
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -98,7 +95,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.getProperties();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -107,7 +104,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.getIndexes();
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -117,7 +114,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.ensurePersistentIndex(fields, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -127,7 +124,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.ensureGeoIndex(fields, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -138,7 +135,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.ensureFulltextIndex(fields, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -147,7 +144,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.ensureTtlIndex(fields, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -156,7 +153,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			collection.deleteIndex(id);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -165,7 +162,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			collection.grantAccess(username, permissions);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -174,7 +171,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			collection.resetAccess(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -183,7 +180,7 @@ public class DefaultCollectionOperations implements CollectionOperations {
 		try {
 			return collection.getPermissions(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/template/DefaultUserOperation.java
+++ b/src/main/java/com/arangodb/springframework/core/template/DefaultUserOperation.java
@@ -21,6 +21,7 @@
 package com.arangodb.springframework.core.template;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 
 import com.arangodb.ArangoDBException;
@@ -57,16 +58,12 @@ public class DefaultUserOperation implements UserOperations {
 		this.collectionCallback = collectionCallback;
 	}
 
-	private DataAccessException translateExceptionIfPossible(final RuntimeException exception) {
-		return exceptionTranslator.translateExceptionIfPossible(exception);
-	}
-
 	@Override
 	public UserEntity get() throws DataAccessException {
 		try {
 			return db.arango().getUser(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -75,7 +72,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			return db.arango().createUser(username, passwd);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -84,7 +81,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			return db.arango().updateUser(username, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -93,7 +90,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			return db.arango().replaceUser(username, options);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -102,7 +99,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			db.arango().deleteUser(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -111,7 +108,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			db.arango().grantDefaultDatabaseAccess(username, permissions);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -120,7 +117,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			db.grantAccess(username, permissions);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -129,7 +126,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			db.resetAccess(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -138,7 +135,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			db.grantDefaultCollectionAccess(username, permissions);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 
@@ -167,7 +164,7 @@ public class DefaultUserOperation implements UserOperations {
 		try {
 			return db.getPermissions(username);
 		} catch (final ArangoDBException e) {
-			throw translateExceptionIfPossible(e);
+			throw DataAccessUtils.translateIfNecessary(e, exceptionTranslator);
 		}
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoErrors.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoErrors.java
@@ -21,55 +21,71 @@
 package com.arangodb.springframework.core.util;
 
 /**
+ * @see <a href="https://github.com/arangodb/arangodb/blob/devel/lib/Basics/errors.dat">General ArangoDB storage errors</a>
  * @author Mark Vollmary
  * @author Christian Lechner
- *
+ * @author Arne Burmeister
  */
 public class ArangoErrors {
 
 	/**
-	 * bad parameter. Will be raised when the HTTP request does not fulfill the requirements.
+	 * Bad parameter, will be raised when the HTTP request does not fulfill the requirements.
 	 */
 	public static final int ERROR_HTTP_BAD_PARAMETER = 400;
 
 	/**
-	 * unauthorized. Will be raised when authorization is required but the user is not authorized.
+	 * Unauthorized, will be raised when authorization is required but the user is not authorized.
 	 */
 	public static final int ERROR_HTTP_UNAUTHORIZED = 401;
 
 	/**
-	 * forbidden. Will be raised when the operation is forbidden.
+	 * Forbidden, will be raised when the operation is forbidden.
 	 */
 	public static final int ERROR_HTTP_FORBIDDEN = 403;
 
 	/**
-	 * not found. Will be raised when an URI is unknown.
+	 * Not found, will be raised when an URI is unknown.
 	 */
 	public static final int ERROR_HTTP_NOT_FOUND = 404;
 
 	/**
-	 * method not supported. Will be raised when an unsupported HTTP method is used for an operation.
+	 * Method not supported, will be raised when an unsupported HTTP method is used for an operation.
 	 */
 	public static final int ERROR_HTTP_METHOD_NOT_ALLOWED = 405;
 
 	/**
-	 * conflict. Will be raised when a conflict is encountered.
+	 * Conflict, will be raised when a conflict is encountered.
 	 */
 	public static final int ERROR_HTTP_CONFLICT = 409;
 
 	/**
-	 * precondition failed. Will be raised when a precondition for an HTTP request is not met.
+	 * Precondition failed, will be raised when a precondition for an HTTP request is not met.
 	 */
 	public static final int ERROR_HTTP_PRECONDITION_FAILED = 412;
 
 	/**
-	 * internal server error. Will be raised when an internal server is encountered.
+	 * Internal server error, will be raised when an internal server is encountered.
 	 */
 	public static final int ERROR_HTTP_SERVER_ERROR = 500;
 
 	/**
-	 * service unavailable. Will be raised when a service is temporarily unavailable.
+	 * Service unavailable, will be raised when a service is temporarily unavailable.
 	 */
 	public static final int ERROR_HTTP_SERVICE_UNAVAILABLE = 503;
+
+	/**
+	 * Conflict, will be raised when updating or deleting a document and a conflict has been detected.
+	 */
+	public static final int ERROR_ARANGO_CONFLICT = 1200;
+
+	/**
+	 * Document not found, will be raised when a document with a given identifier is unknown.
+	 */
+	public static final int ERROR_ARANGO_DOCUMENT_NOT_FOUND = 1202;
+
+	/**
+	 * Unique constraint violated, will be raised when there is a unique constraint violation.
+	 */
+	public static final int ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED = 1210;
 
 }

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
@@ -25,17 +25,18 @@ import org.springframework.dao.support.PersistenceExceptionTranslator;
 
 import com.arangodb.ArangoDBException;
 import com.arangodb.springframework.ArangoUncategorizedException;
+import org.springframework.lang.Nullable;
 
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
+import static com.arangodb.springframework.core.util.ArangoErrors.*;
 import static java.util.Map.entry;
 
 /**
  * Translate any {@link ArangoDBException} to the appropriate {@link DataAccessException} using response code and error number.
  *
- * @see <a href="https://github.com/arangodb/arangodb/blob/devel/lib/Basics/errors.dat">General ArangoDB storage errors</a>
  * @author Mark Vollmary
  * @author Christian Lechner
  * @author Arne Burmeister
@@ -43,36 +44,35 @@ import static java.util.Map.entry;
 public class ArangoExceptionTranslator implements PersistenceExceptionTranslator {
 
 	@Override
+	@Nullable
 	public DataAccessException translateExceptionIfPossible(final RuntimeException ex) {
-		DataAccessException dae = null;
 		if (ex instanceof DataAccessException exception) {
-			dae = exception;
-		} else if (ex instanceof ArangoDBException exception) {
+			return exception;
+		}
+		if (ex instanceof ArangoDBException exception) {
 			final Integer responseCode = exception.getResponseCode();
-			if (responseCode != null) {
-				BiFunction<String, ArangoDBException, DataAccessException> constructor = switch (responseCode) {
-					case ArangoErrors.ERROR_HTTP_UNAUTHORIZED, ArangoErrors.ERROR_HTTP_FORBIDDEN -> PermissionDeniedDataAccessException::new;
-					case ArangoErrors.ERROR_HTTP_BAD_PARAMETER, ArangoErrors.ERROR_HTTP_METHOD_NOT_ALLOWED -> InvalidDataAccessApiUsageException::new;
-					case ArangoErrors.ERROR_HTTP_NOT_FOUND -> mostSpecific(exception, Map.ofEntries(
-								entry(hasErrorNumber(1202), DataRetrievalFailureException::new)
-							), InvalidDataAccessResourceUsageException::new);
-					case ArangoErrors.ERROR_HTTP_CONFLICT -> mostSpecific(exception, Map.ofEntries(
-								entry(hasErrorNumber(1200).and(errorMessageContains("write-write conflict")), TransientDataAccessResourceException::new),
-								entry(hasErrorNumber(1200).and(errorMessageContains("_rev")), OptimisticLockingFailureException::new),
-								entry(hasErrorNumber(1210).and(errorMessageContains("_key")), DuplicateKeyException::new)
-							),
-							DataIntegrityViolationException::new);
-					case ArangoErrors.ERROR_HTTP_PRECONDITION_FAILED -> OptimisticLockingFailureException::new;
-					case ArangoErrors.ERROR_HTTP_SERVICE_UNAVAILABLE -> DataAccessResourceFailureException::new;
-					default -> ArangoUncategorizedException::new;
-				};
-				return constructor.apply(exception.getMessage(), exception);
+			if (responseCode == null) {
+				return new ArangoUncategorizedException(exception.getMessage(), exception);
 			}
+			BiFunction<String, ArangoDBException, DataAccessException> constructor = switch (responseCode) {
+				case ERROR_HTTP_UNAUTHORIZED, ERROR_HTTP_FORBIDDEN -> PermissionDeniedDataAccessException::new;
+				case ERROR_HTTP_BAD_PARAMETER, ERROR_HTTP_METHOD_NOT_ALLOWED -> InvalidDataAccessApiUsageException::new;
+				case ERROR_HTTP_NOT_FOUND -> mostSpecific(exception, Map.ofEntries(
+							entry(hasErrorNumber(ERROR_ARANGO_DOCUMENT_NOT_FOUND), DataRetrievalFailureException::new)
+						), InvalidDataAccessResourceUsageException::new);
+				case ERROR_HTTP_CONFLICT -> mostSpecific(exception, Map.ofEntries(
+							entry(hasErrorNumber(ERROR_ARANGO_CONFLICT).and(errorMessageContains("write-write")), TransientDataAccessResourceException::new),
+							entry(hasErrorNumber(ERROR_ARANGO_CONFLICT).and(errorMessageContains("_rev")), OptimisticLockingFailureException::new),
+							entry(hasErrorNumber(ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED).and(errorMessageContains("_key")), DuplicateKeyException::new)
+						),
+						DataIntegrityViolationException::new);
+				case ERROR_HTTP_PRECONDITION_FAILED -> OptimisticLockingFailureException::new;
+				case ERROR_HTTP_SERVICE_UNAVAILABLE -> DataAccessResourceFailureException::new;
+				default -> ArangoUncategorizedException::new;
+			};
+			return constructor.apply(exception.getMessage(), exception);
 		}
-		if (dae == null) {
-			throw ex;
-		}
-		return dae;
+		return null;
 	}
 
 	private static BiFunction<String, ArangoDBException, DataAccessException> mostSpecific(ArangoDBException exception,
@@ -81,7 +81,7 @@ public class ArangoExceptionTranslator implements PersistenceExceptionTranslator
 		return specific.entrySet().stream()
 				.filter(entry -> entry.getKey().test(exception))
 				.map(Map.Entry::getValue)
-				.findAny()
+				.findFirst()
 				.orElse(fallback);
 	}
 

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
@@ -20,57 +20,53 @@
 
 package com.arangodb.springframework.core.util;
 
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.dao.InvalidDataAccessResourceUsageException;
-import org.springframework.dao.PermissionDeniedDataAccessException;
+import org.springframework.dao.*;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 
 import com.arangodb.ArangoDBException;
 import com.arangodb.springframework.ArangoUncategorizedException;
 
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import static java.util.Map.entry;
+
 /**
+ * Translate any {@link ArangoDBException} to the appropriate {@link DataAccessException} using response code and error number.
+ *
+ * @see <a href="https://github.com/arangodb/arangodb/blob/devel/lib/Basics/errors.dat">General ArangoDB storage errors</a>
  * @author Mark Vollmary
  * @author Christian Lechner
- *
+ * @author Arne Burmeister
  */
 public class ArangoExceptionTranslator implements PersistenceExceptionTranslator {
 
 	@Override
 	public DataAccessException translateExceptionIfPossible(final RuntimeException ex) {
 		DataAccessException dae = null;
-		if (ex instanceof DataAccessException) {
-			dae = DataAccessException.class.cast(ex);
-		} else if (ex instanceof ArangoDBException) {
-			final ArangoDBException exception = ArangoDBException.class.cast(ex);
+		if (ex instanceof DataAccessException exception) {
+			dae = exception;
+		} else if (ex instanceof ArangoDBException exception) {
 			final Integer responseCode = exception.getResponseCode();
 			if (responseCode != null) {
-				switch (responseCode) {
-				case ArangoErrors.ERROR_HTTP_UNAUTHORIZED:
-				case ArangoErrors.ERROR_HTTP_FORBIDDEN:
-					dae = new PermissionDeniedDataAccessException(exception.getMessage(), exception);
-					break;
-				case ArangoErrors.ERROR_HTTP_BAD_PARAMETER:
-				case ArangoErrors.ERROR_HTTP_METHOD_NOT_ALLOWED:
-					dae = new InvalidDataAccessApiUsageException(exception.getMessage(), exception);
-					break;
-				case ArangoErrors.ERROR_HTTP_NOT_FOUND:
-					dae = new InvalidDataAccessResourceUsageException(exception.getMessage(), exception);
-					break;
-				case ArangoErrors.ERROR_HTTP_CONFLICT:
-					dae = new DataIntegrityViolationException(exception.getMessage(), exception);
-					break;
-				case ArangoErrors.ERROR_HTTP_PRECONDITION_FAILED:
-				case ArangoErrors.ERROR_HTTP_SERVICE_UNAVAILABLE:
-					dae = new DataAccessResourceFailureException(exception.getMessage(), exception);
-					break;
-				case ArangoErrors.ERROR_HTTP_SERVER_ERROR:
-				default:
-					dae = new ArangoUncategorizedException(exception.getMessage(), exception);
-					break;
-				}
+				BiFunction<String, ArangoDBException, DataAccessException> constructor = switch (responseCode) {
+					case ArangoErrors.ERROR_HTTP_UNAUTHORIZED, ArangoErrors.ERROR_HTTP_FORBIDDEN -> PermissionDeniedDataAccessException::new;
+					case ArangoErrors.ERROR_HTTP_BAD_PARAMETER, ArangoErrors.ERROR_HTTP_METHOD_NOT_ALLOWED -> InvalidDataAccessApiUsageException::new;
+					case ArangoErrors.ERROR_HTTP_NOT_FOUND -> mostSpecific(exception, Map.ofEntries(
+								entry(hasErrorNumber(1202), DataRetrievalFailureException::new)
+							), InvalidDataAccessResourceUsageException::new);
+					case ArangoErrors.ERROR_HTTP_CONFLICT -> mostSpecific(exception, Map.ofEntries(
+								entry(hasErrorNumber(1200).and(errorMessageContains("write-write conflict")), TransientDataAccessResourceException::new),
+								entry(hasErrorNumber(1200).and(errorMessageContains("_rev")), OptimisticLockingFailureException::new),
+								entry(hasErrorNumber(1210).and(errorMessageContains("_key")), DuplicateKeyException::new)
+							),
+							DataIntegrityViolationException::new);
+					case ArangoErrors.ERROR_HTTP_PRECONDITION_FAILED -> OptimisticLockingFailureException::new;
+					case ArangoErrors.ERROR_HTTP_SERVICE_UNAVAILABLE -> DataAccessResourceFailureException::new;
+					default -> ArangoUncategorizedException::new;
+				};
+				return constructor.apply(exception.getMessage(), exception);
 			}
 		}
 		if (dae == null) {
@@ -79,4 +75,21 @@ public class ArangoExceptionTranslator implements PersistenceExceptionTranslator
 		return dae;
 	}
 
+	private static BiFunction<String, ArangoDBException, DataAccessException> mostSpecific(ArangoDBException exception,
+											 Map<Predicate<ArangoDBException>, BiFunction<String, ArangoDBException, DataAccessException>> specific,
+											 BiFunction<String, ArangoDBException, DataAccessException> fallback) {
+		return specific.entrySet().stream()
+				.filter(entry -> entry.getKey().test(exception))
+				.map(Map.Entry::getValue)
+				.findAny()
+				.orElse(fallback);
+	}
+
+	private static Predicate<ArangoDBException> hasErrorNumber(int expected) {
+		return exception -> exception.getErrorNum() != null && exception.getErrorNum() == expected;
+	}
+
+	private static Predicate<ArangoDBException> errorMessageContains(String expected) {
+		return exception -> exception.getErrorMessage() != null && exception.getErrorMessage().contains(expected);
+	}
 }

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
@@ -66,7 +66,10 @@ public class ArangoExceptionTranslator implements PersistenceExceptionTranslator
 							entry(hasErrorNumber(ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED).and(errorMessageContains("_key")), DuplicateKeyException::new)
 						),
 						DataIntegrityViolationException::new);
-				case ERROR_HTTP_PRECONDITION_FAILED -> OptimisticLockingFailureException::new;
+				case ERROR_HTTP_PRECONDITION_FAILED -> mostSpecific(exception, Map.ofEntries(
+								entry(hasErrorNumber(ERROR_ARANGO_CONFLICT).and(errorMessageContains("_rev")), OptimisticLockingFailureException::new)
+						),
+						DataAccessResourceFailureException::new);
 				case ERROR_HTTP_SERVICE_UNAVAILABLE -> DataAccessResourceFailureException::new;
 				default -> ArangoUncategorizedException::new;
 			};

--- a/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
+++ b/src/test/java/com/arangodb/springframework/core/template/ArangoTemplateTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import java.util.stream.StreamSupport;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
@@ -113,6 +115,13 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 		assertThat(customer.getAge(), is(30));
 		assertThat(customer.getAddress(), is(notNullValue()));
 		assertThat(customer.getAddress().getZipCode(), is("22162–1010"));
+	}
+
+
+	@Test
+	public void deleteUnknownDocument() {
+		assertThrows(DataRetrievalFailureException.class,
+				() -> template.delete("9999", Customer.class));
 	}
 
 	@Test
@@ -261,6 +270,12 @@ public class ArangoTemplateTest extends AbstractArangoTest {
 		assertThat(customers.get(0).getName(), is("John"));
 		assertThat(customers.get(0).getSurname(), is("Doe"));
 		assertThat(customers.get(0).getAge(), is(30));
+	}
+
+	@Test
+	public void updateQueryForUnknown() {
+		assertThrows(DataRetrievalFailureException.class,
+				() -> template.query("UPDATE '9999' WITH { age: 99 } IN `test-customer` RETURN NEW", Customer.class));
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -1,7 +1,6 @@
 package com.arangodb.springframework.repository.query;
 
 import com.arangodb.ArangoCursor;
-import com.arangodb.ArangoDBException;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.repository.AbstractArangoRepositoryTest;


### PR DESCRIPTION
Fix for #281:
* use recommended `DataAccessUtils.translateIfNecessary()`
* handle some errors in a more specific way:
  - errorNumber 1202 as `DataRetrievalFailureException`
  - errorNumber 1200 and message with `write-write` conflict as `TransientDataAccessResourceException`
  - errorNumber 1200 and message with `_rev` conflict as `OptimisticLockingFailureException`
  - errorNumer 1210 and message with `_key` as `DuplicateKeyException`