### PR TITLE
[DE-683] ignore unknown id on crud repo deleteById()

### DIFF
--- a/src/main/java/com/arangodb/springframework/core/DocumentNotFoundException.java
+++ b/src/main/java/com/arangodb/springframework/core/DocumentNotFoundException.java
@@ -1,0 +1,13 @@
+package com.arangodb.springframework.core;
+
+import org.springframework.dao.DataRetrievalFailureException;
+
+public class DocumentNotFoundException extends DataRetrievalFailureException {
+    public DocumentNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public DocumentNotFoundException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
+++ b/src/main/java/com/arangodb/springframework/core/util/ArangoExceptionTranslator.java
@@ -20,6 +20,7 @@
 
 package com.arangodb.springframework.core.util;
 
+import com.arangodb.springframework.core.DocumentNotFoundException;
 import org.springframework.dao.*;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 
@@ -58,7 +59,7 @@ public class ArangoExceptionTranslator implements PersistenceExceptionTranslator
 				case ERROR_HTTP_UNAUTHORIZED, ERROR_HTTP_FORBIDDEN -> PermissionDeniedDataAccessException::new;
 				case ERROR_HTTP_BAD_PARAMETER, ERROR_HTTP_METHOD_NOT_ALLOWED -> InvalidDataAccessApiUsageException::new;
 				case ERROR_HTTP_NOT_FOUND -> mostSpecific(exception, Map.ofEntries(
-							entry(hasErrorNumber(ERROR_ARANGO_DOCUMENT_NOT_FOUND), DataRetrievalFailureException::new)
+							entry(hasErrorNumber(ERROR_ARANGO_DOCUMENT_NOT_FOUND), DocumentNotFoundException::new)
 						), InvalidDataAccessResourceUsageException::new);
 				case ERROR_HTTP_CONFLICT -> mostSpecific(exception, Map.ofEntries(
 							entry(hasErrorNumber(ERROR_ARANGO_CONFLICT).and(errorMessageContains("write-write")), TransientDataAccessResourceException::new),

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -27,6 +27,7 @@ import com.arangodb.springframework.core.mapping.ArangoMappingContext;
 import com.arangodb.springframework.core.util.AqlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.domain.*;
 import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.lang.Nullable;
@@ -152,7 +153,11 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public void deleteById(final ID id) {
-		arangoOperations.delete(id, domainClass);
+		try {
+			arangoOperations.delete(id, domainClass);
+		} catch (DataRetrievalFailureException unknown) {
+			// silently ignored
+		}
 	}
 
 	/**

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -23,11 +23,11 @@ package com.arangodb.springframework.repository;
 import com.arangodb.ArangoCursor;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.springframework.core.ArangoOperations;
+import com.arangodb.springframework.core.DocumentNotFoundException;
 import com.arangodb.springframework.core.mapping.ArangoMappingContext;
 import com.arangodb.springframework.core.util.AqlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.domain.*;
 import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.lang.Nullable;
@@ -155,8 +155,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	public void deleteById(final ID id) {
 		try {
 			arangoOperations.delete(id, domainClass);
-		} catch (DataRetrievalFailureException unknown) {
-			// silently ignored
+		} catch (DocumentNotFoundException unknown) {
+//			 silently ignored
 		}
 	}
 

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -272,6 +272,14 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 	}
 
 	@Test
+	public void deleteById() {
+		repository.saveAll(customers);
+		repository.deleteById(john.getId());
+		assertThat(repository.findById(john.getId()).isPresent(), is(false));
+		repository.deleteById("9999");
+	}
+
+	@Test
 	public void overriddenCrudMethodsTest() {
 		overriddenRepository.saveAll(customers);
 		final Iterator<Customer> customers = overriddenRepository.findAll().iterator();

--- a/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/query/ArangoAqlQueryTest.java
@@ -276,7 +276,7 @@ public class ArangoAqlQueryTest extends AbstractArangoRepositoryTest {
 		repository.saveAll(customers);
 		repository.deleteById(john.getId());
 		assertThat(repository.findById(john.getId()).isPresent(), is(false));
-		repository.deleteById("9999");
+		repository.deleteById(john.getId());
 	}
 
 	@Test


### PR DESCRIPTION
`CrudRepository.deleteById()` has a contract of ignoring unknown ids silently