### PR TITLE
[DE-539] Feature #291 CRUD save returning server result

### DIFF
--- a/src/main/java/com/arangodb/springframework/config/ArangoConfiguration.java
+++ b/src/main/java/com/arangodb/springframework/config/ArangoConfiguration.java
@@ -61,6 +61,16 @@ public interface ArangoConfiguration {
     String database();
 
     /**
+     * Configures the behaviour of {@link com.arangodb.springframework.repository.ArangoRepository#save(Object)} and
+     * {@link com.arangodb.springframework.repository.ArangoRepository#saveAll(Iterable)} to either return the original
+     * entities (updated where possible) or new ones.
+     * Set to {@code false} to use immutable entity classes or java records.
+     */
+    default boolean returnOriginalEntities() {
+        return true;
+    }
+
+    /**
      * Override to set the data format to use in {@link #serde()}. It must match the content-type required by the
      * protocol used in the driver, e.g. set to {@link ContentType#VPACK} for protocols
      * {@link com.arangodb.Protocol#VST}, {@link com.arangodb.Protocol#HTTP_VPACK} and

--- a/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
+++ b/src/main/java/com/arangodb/springframework/core/template/ArangoTemplate.java
@@ -161,6 +161,7 @@ public class ArangoTemplate implements ArangoOperations, CollectionCallback, App
         return collection;
     }
 
+    @SuppressWarnings("deprecation")
     private static void ensureCollectionIndexes(final CollectionOperations collection,
                                                 final ArangoPersistentEntity<?> persistentEntity) {
         persistentEntity.getPersistentIndexes().forEach(index -> ensurePersistentIndex(collection, index));

--- a/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
@@ -59,6 +59,7 @@ public class ArangoRepositoryFactory extends RepositoryFactorySupport {
 
 	private final ArangoOperations arangoOperations;
 	private final ApplicationContext applicationContext;
+	private boolean returnOriginalEntities = true;
 	private final MappingContext<? extends ArangoPersistentEntity<?>, ArangoPersistentProperty> context;
 
 	public ArangoRepositoryFactory(final ArangoOperations arangoOperations, final ApplicationContext applicationContext) {
@@ -74,10 +75,21 @@ public class ArangoRepositoryFactory extends RepositoryFactorySupport {
 				(ArangoPersistentEntity<T>) context.getRequiredPersistentEntity(domainClass));
 	}
 
+	/**
+	 * Change the behaviour of {@link org.springframework.data.repository.CrudRepository#save(Object)} and
+	 * {@link org.springframework.data.repository.CrudRepository#saveAll(Iterable)} to either return the original
+	 * entities passed or those returned from the server using proxies for lazy evaluation.
+	 *
+	 * @see org.springframework.data.repository.core.support.RepositoryFactoryCustomizer
+	 */
+	public void setReturnOriginalEntities(boolean returnOriginalEntities) {
+		this.returnOriginalEntities = returnOriginalEntities;
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	protected Object getTargetRepository(final RepositoryInformation metadata) {
-		return new SimpleArangoRepository(arangoOperations, metadata.getDomainType());
+		return new SimpleArangoRepository(arangoOperations, metadata.getDomainType(), returnOriginalEntities);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactory.java
@@ -23,6 +23,7 @@ package com.arangodb.springframework.repository;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+import com.arangodb.springframework.config.ArangoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
@@ -59,31 +60,23 @@ public class ArangoRepositoryFactory extends RepositoryFactorySupport {
 
 	private final ArangoOperations arangoOperations;
 	private final ApplicationContext applicationContext;
-	private boolean returnOriginalEntities = true;
+	private final boolean returnOriginalEntities;
 	private final MappingContext<? extends ArangoPersistentEntity<?>, ArangoPersistentProperty> context;
 
-	public ArangoRepositoryFactory(final ArangoOperations arangoOperations, final ApplicationContext applicationContext) {
-		this.arangoOperations = arangoOperations;
-		this.applicationContext = applicationContext;
-		this.context = arangoOperations.getConverter().getMappingContext();
-	}
+    public ArangoRepositoryFactory(final ArangoOperations arangoOperations,
+                                   final ApplicationContext applicationContext,
+                                   final ArangoConfiguration arangoConfiguration) {
+        this.arangoOperations = arangoOperations;
+        this.applicationContext = applicationContext;
+        this.context = arangoOperations.getConverter().getMappingContext();
+        returnOriginalEntities = arangoConfiguration.returnOriginalEntities();
+    }
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T, ID> ArangoEntityInformation<T, ID> getEntityInformation(final Class<T> domainClass) {
 		return new ArangoPersistentEntityInformation<>(
 				(ArangoPersistentEntity<T>) context.getRequiredPersistentEntity(domainClass));
-	}
-
-	/**
-	 * Change the behaviour of {@link org.springframework.data.repository.CrudRepository#save(Object)} and
-	 * {@link org.springframework.data.repository.CrudRepository#saveAll(Iterable)} to either return the original
-	 * entities passed or those returned from the server using proxies for lazy evaluation.
-	 *
-	 * @see org.springframework.data.repository.core.support.RepositoryFactoryCustomizer
-	 */
-	public void setReturnOriginalEntities(boolean returnOriginalEntities) {
-		this.returnOriginalEntities = returnOriginalEntities;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactoryBean.java
+++ b/src/main/java/com/arangodb/springframework/repository/ArangoRepositoryFactoryBean.java
@@ -20,6 +20,7 @@
 
 package com.arangodb.springframework.repository;
 
+import com.arangodb.springframework.config.ArangoConfiguration;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -39,6 +40,7 @@ public class ArangoRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 
 	private ArangoOperations arangoOperations;
 	private ApplicationContext applicationContext;
+	private ArangoConfiguration arangoConfiguration;
 
 	@Autowired
 	public ArangoRepositoryFactoryBean(final Class<? extends T> repositoryInterface) {
@@ -50,10 +52,15 @@ public class ArangoRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 		this.arangoOperations = arangoOperations;
 	}
 
+	@Autowired
+	public void setArangoConfiguration(final ArangoConfiguration arangoConfiguration) {
+		this.arangoConfiguration = arangoConfiguration;
+	}
+
 	@Override
 	protected RepositoryFactorySupport createRepositoryFactory() {
 		Assert.notNull(arangoOperations, "arangoOperations not configured");
-		return new ArangoRepositoryFactory(arangoOperations, applicationContext);
+		return new ArangoRepositoryFactory(arangoOperations, applicationContext, arangoConfiguration);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -58,7 +58,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 *                               functionality of this class
 	 * @param domainClass            the class type of this repository
 	 * @param returnOriginalEntities whether save and saveAll should return the
-	 *                               original entities passed or the server ones
+	 *                               original entities or new ones
 	 */
 	public SimpleArangoRepository(final ArangoOperations arangoOperations, final Class<T> domainClass, boolean returnOriginalEntities) {
 		super();

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -51,17 +51,20 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	private final ArangoMappingContext mappingContext;
 	private final ArangoExampleConverter exampleConverter;
 	private final Class<T> domainClass;
+	private final boolean returnOriginalEntities;
 
 	/**
-	 *
-	 * @param arangoOperations The template used to execute much of the
-	 *                         functionality of this class
-	 * @param domainClass      the class type of this repository
+	 * @param arangoOperations       The template used to execute much of the
+	 *                               functionality of this class
+	 * @param domainClass            the class type of this repository
+	 * @param returnOriginalEntities whether save and saveAll should return the
+	 *                               original entities passed or the server ones
 	 */
-	public SimpleArangoRepository(final ArangoOperations arangoOperations, final Class<T> domainClass) {
+	public SimpleArangoRepository(final ArangoOperations arangoOperations, final Class<T> domainClass, boolean returnOriginalEntities) {
 		super();
 		this.arangoOperations = arangoOperations;
 		this.domainClass = domainClass;
+		this.returnOriginalEntities = returnOriginalEntities;
 		mappingContext = (ArangoMappingContext) arangoOperations.getConverter().getMappingContext();
 		exampleConverter = new ArangoExampleConverter(mappingContext, arangoOperations.getResolverFactory());
 	}
@@ -74,7 +77,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> S save(final S entity) {
-		return arangoOperations.repsert(entity);
+		S saved = arangoOperations.repsert(entity);
+		return returnOriginalEntities ? entity : saved;
 	}
 
 	/**
@@ -86,7 +90,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> Iterable<S> saveAll(final Iterable<S> entities) {
-		return arangoOperations.repsertAll(entities, domainClass);
+		Iterable<S> saved = arangoOperations.repsertAll(entities, domainClass);
+		return returnOriginalEntities ? entities : saved;
 	}
 
 	/**

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -166,13 +166,8 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public void delete(final T entity) {
-		String id = null;
-		try {
-			id = (String) arangoOperations.getConverter().getMappingContext().getPersistentEntity(domainClass)
-					.getIdProperty().getField().get(entity);
-		} catch (final IllegalAccessException e) {
-			e.printStackTrace();
-		}
+		String id = (String) arangoOperations.getConverter().getMappingContext()
+				.getRequiredPersistentEntity(domainClass).getIdentifierAccessor(entity).getRequiredIdentifier();
 		arangoOperations.delete(id, domainClass);
 	}
 
@@ -268,8 +263,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> Iterable<S> findAll(final Example<S> example) {
-		final ArangoCursor cursor = findAllInternal((Pageable) null, example, new HashMap<>());
-		return cursor;
+		return (ArangoCursor) findAllInternal((Pageable) null, example, new HashMap<>());
 	}
 
 	/**
@@ -283,8 +277,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> Iterable<S> findAll(final Example<S> example, final Sort sort) {
-		final ArangoCursor cursor = findAllInternal(sort, example, new HashMap());
-		return cursor;
+		return findAllInternal(sort, example, new HashMap());
 	}
 
 	/**

--- a/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
+++ b/src/main/java/com/arangodb/springframework/repository/SimpleArangoRepository.java
@@ -74,8 +74,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> S save(final S entity) {
-		arangoOperations.repsert(entity);
-		return entity;
+		return arangoOperations.repsert(entity);
 	}
 
 	/**
@@ -87,8 +86,7 @@ public class SimpleArangoRepository<T, ID> implements ArangoRepository<T, ID> {
 	 */
 	@Override
 	public <S extends T> Iterable<S> saveAll(final Iterable<S> entities) {
-		arangoOperations.repsertAll(entities, domainClass);
-		return entities;
+		return arangoOperations.repsertAll(entities, domainClass);
 	}
 
 	/**

--- a/src/test/java/com/arangodb/springframework/AbstractArangoTest.java
+++ b/src/test/java/com/arangodb/springframework/AbstractArangoTest.java
@@ -22,18 +22,15 @@ package com.arangodb.springframework;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.arangodb.springframework.core.ArangoOperations;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Mark Vollmary
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = { ArangoTestConfiguration.class })
+@SpringJUnitConfig(ArangoTestConfiguration.class)
 public abstract class AbstractArangoTest {
 
 	private static volatile ArangoOperations staticTemplate;

--- a/src/test/java/com/arangodb/springframework/ArangoTestConfiguration.java
+++ b/src/test/java/com/arangodb/springframework/ArangoTestConfiguration.java
@@ -32,7 +32,7 @@ import com.arangodb.springframework.core.mapping.CustomMappingTest;
 import com.arangodb.springframework.repository.ArangoRepositoryFactory;
 import com.arangodb.springframework.testdata.Person;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -62,19 +62,23 @@ public class ArangoTestConfiguration implements ArangoConfiguration {
 
     public static final String DB = "spring-test-db";
 
-    @Value("${arangodb.protocol:HTTP2_JSON}")
-    private Protocol protocol;
+    @Autowired
+    private Environment env;
+
+    private Protocol getProtocol() {
+        return env.getProperty("arangodb.protocol", Protocol.class, Protocol.HTTP2_JSON);
+    }
 
     @Override
     public ArangoDB.Builder arango() {
         return new ArangoDB.Builder()
                 .loadProperties(ArangoConfigProperties.fromFile())
-                .protocol(protocol);
+                .protocol(getProtocol());
     }
 
     @Override
     public ContentType contentType() {
-        return ContentTypeFactory.of(protocol);
+        return ContentTypeFactory.of(getProtocol());
     }
 
     @Override
@@ -98,7 +102,7 @@ public class ArangoTestConfiguration implements ArangoConfiguration {
 	}
 
 	@Bean
-	public BeanPostProcessor repositoryFactoryCustomizerRegistrar(Environment env) {
+	public BeanPostProcessor repositoryFactoryCustomizerRegistrar() {
 		boolean returnOriginalEntities = env.getProperty("returnOriginalEntities", Boolean.class, true);
 		return new BeanPostProcessor() {
 			@Override

--- a/src/test/java/com/arangodb/springframework/ArangoTestConfiguration.java
+++ b/src/test/java/com/arangodb/springframework/ArangoTestConfiguration.java
@@ -29,13 +29,19 @@ import com.arangodb.springframework.annotation.EnableArangoAuditing;
 import com.arangodb.springframework.annotation.EnableArangoRepositories;
 import com.arangodb.springframework.config.ArangoConfiguration;
 import com.arangodb.springframework.core.mapping.CustomMappingTest;
+import com.arangodb.springframework.repository.ArangoRepositoryFactory;
 import com.arangodb.springframework.testdata.Person;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.env.Environment;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.core.support.RepositoryFactoryCustomizer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,8 +92,26 @@ public class ArangoTestConfiguration implements ArangoConfiguration {
         return converters;
     }
 
-    @Bean
-    public AuditorAware<Person> auditorProvider() {
-        return new AuditorProvider();
-    }
+	@Bean
+	public AuditorAware<Person> auditorProvider() {
+		return new AuditorProvider();
+	}
+
+	@Bean
+	public BeanPostProcessor repositoryFactoryCustomizerRegistrar(Environment env) {
+		boolean returnOriginalEntities = env.getProperty("returnOriginalEntities", Boolean.class, true);
+		return new BeanPostProcessor() {
+			@Override
+			public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+				if (bean instanceof RepositoryFactoryBeanSupport<?, ?, ?> repoFactoryBean) {
+					repoFactoryBean.addRepositoryFactoryCustomizer(repositoryFactoryCustomizer(returnOriginalEntities));
+				}
+				return bean;
+			}
+		};
+	}
+
+	private static RepositoryFactoryCustomizer repositoryFactoryCustomizer(boolean returnOriginalEntities) {
+		return factory -> ((ArangoRepositoryFactory) factory).setReturnOriginalEntities(returnOriginalEntities);
+	}
 }

--- a/src/test/java/com/arangodb/springframework/core/template/ArangoIndexTest.java
+++ b/src/test/java/com/arangodb/springframework/core/template/ArangoIndexTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.*;
  * @author Mark Vollmary
  *
  */
+@SuppressWarnings("deprecation")
 public class ArangoIndexTest extends AbstractArangoTest {
 
 	private IndexType geo1() {

--- a/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.util.*;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.*;
 import org.springframework.data.domain.ExampleMatcher.StringMatcher;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.ExampleMatcher.StringMatcher;
 import com.arangodb.springframework.testdata.Address;
 import com.arangodb.springframework.testdata.Customer;
 import com.arangodb.springframework.testdata.ShoppingCart;
+import org.springframework.data.util.Streamable;
 
 /**
  * Created by F625633 on 06/07/2017.
@@ -21,8 +23,9 @@ public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
 	@Test
 	public void saveTest() {
 		Customer res = repository.save(john);
-		assertThat(res, sameInstance(john));
+		assertThat(res, not(sameInstance(john)));
 		assertThat(res.getId(), is(notNullValue()));
+		assertThat(res.getId(), equalTo(john.getId()));
 	}
 
 	@Test
@@ -39,11 +42,9 @@ public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
 
 	@Test
 	public void saveAllTest() {
-		Iterable<Customer> res = repository.saveAll(customers);
-		Iterator<Customer> cIt = customers.iterator();
-        for (Customer re : res) {
-            assertThat(re, sameInstance(cIt.next()));
-        }
+		List<Customer> res = Streamable.of(repository.saveAll(customers)).toList();
+		assertThat(res, Matchers.hasSize(customers.size()));
+		assertThat(res, Matchers.hasItems(customers.toArray(Customer[]::new)));
         Iterable<Customer> docs = repository.findAll();
 		docs.forEach(d -> d.setName("saveAllTest"));
 		repository.saveAll(docs);

--- a/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
@@ -1,575 +1,616 @@
 package com.arangodb.springframework.repository;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
-import java.util.*;
-
+import com.arangodb.springframework.testdata.Address;
+import com.arangodb.springframework.testdata.Customer;
+import com.arangodb.springframework.testdata.ShoppingCart;
+import com.arangodb.springframework.testdata.UserRecord;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.*;
 import org.springframework.data.domain.ExampleMatcher.StringMatcher;
-
-import com.arangodb.springframework.testdata.Address;
-import com.arangodb.springframework.testdata.Customer;
-import com.arangodb.springframework.testdata.ShoppingCart;
 import org.springframework.data.util.Streamable;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Created by F625633 on 06/07/2017.
  */
 public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
 
-	@Nested
-	public class ReturnOriginalEntities {
+    @Nested
+    public class ReturnOriginalEntities {
 
-		@Autowired
-		protected CustomerRepository repository;
+        @Autowired
+        protected CustomerRepository repository;
 
-		@Test
-		public void saveTest() {
-			Customer res = repository.save(john);
-			assertThat(res, sameInstance(john));
-			assertThat(res.getId(), is(notNullValue()));
-			assertThat(res.getId(), equalTo(john.getId()));
-		}
+        @Test
+        public void saveTest() {
+            Customer res = repository.save(john);
+            assertThat(res, sameInstance(john));
+            assertThat(res.getId(), is(notNullValue()));
+            assertThat(res.getId(), equalTo(john.getId()));
+        }
 
-		@Test
-		public void saveAllTest() {
-			Iterable<Customer> res = repository.saveAll(customers);
-			Iterator<Customer> cIt = customers.iterator();
-			for (Customer re : res) {
-				assertThat(re, sameInstance(cIt.next()));
-			}
-			Iterable<Customer> docs = repository.findAll();
-			docs.forEach(d -> d.setName("saveAllTest"));
-			repository.saveAll(docs);
-			repository.findAll().forEach(it -> assertThat("name does not match", it.getName(), equalTo("saveAllTest")));
-		}
-	}
+        @Test
+        public void saveAllTest() {
+            Iterable<Customer> res = repository.saveAll(customers);
+            Iterator<Customer> cIt = customers.iterator();
+            for (Customer re : res) {
+                assertThat(re, sameInstance(cIt.next()));
+            }
+            Iterable<Customer> docs = repository.findAll();
+            docs.forEach(d -> d.setName("saveAllTest"));
+            repository.saveAll(docs);
+            repository.findAll().forEach(it -> assertThat("name does not match", it.getName(), equalTo("saveAllTest")));
+        }
+    }
 
-	@Nested
-	@TestPropertySource(properties = "returnOriginalEntities=false")
-	public class ReturnServerResult {
+    @Nested
+    @TestPropertySource(properties = "returnOriginalEntities=false")
+    public class ReturnServerResult {
 
-		@Autowired
-		protected CustomerRepository repository;
+        @Autowired
+        protected CustomerRepository repository;
 
-		@Test
-		public void saveTest() {
-			Customer res = repository.save(john);
-			assertThat(res, not(sameInstance(john)));
-			assertThat(res.getId(), is(notNullValue()));
-			assertThat(res.getId(), equalTo(john.getId()));
-		}
+        @Test
+        public void saveTest() {
+            Customer res = repository.save(john);
+            assertThat(res, not(sameInstance(john)));
+            assertThat(res.getId(), is(notNullValue()));
+            assertThat(res.getId(), equalTo(john.getId()));
+        }
 
-		@Test
-		public void saveAllTest() {
-			List<Customer> res = Streamable.of(repository.saveAll(customers)).toList();
-			assertThat(res, Matchers.hasSize(customers.size()));
-			assertThat(res, Matchers.hasItems(customers.toArray(Customer[]::new)));
-			for (Customer original : customers) {
-				assertThat(res, everyItem(not(sameInstance(original))));
-			}
-			Iterable<Customer> docs = repository.findAll();
-			docs.forEach(d -> d.setName("saveAllTest"));
-			repository.saveAll(docs);
-			repository.findAll().forEach(it -> assertThat("name does not match", it.getName(), equalTo("saveAllTest")));
-		}
-	}
+        @Test
+        public void saveAllTest() {
+            List<Customer> res = Streamable.of(repository.saveAll(customers)).toList();
+            assertThat(res, Matchers.hasSize(customers.size()));
+            assertThat(res, Matchers.hasItems(customers.toArray(Customer[]::new)));
+            for (Customer original : customers) {
+                assertThat(res, everyItem(not(sameInstance(original))));
+            }
+            Iterable<Customer> docs = repository.findAll();
+            docs.forEach(d -> d.setName("saveAllTest"));
+            repository.saveAll(docs);
+            repository.findAll().forEach(it -> assertThat("name does not match", it.getName(), equalTo("saveAllTest")));
+        }
+    }
 
-	@Test
-	public void findOneTest() {
-		repository.save(john);
-		final String id = john.getId();
-		Customer customer = repository.findById(id).get();
-		assertThat("customers do not match", customer, equalTo(john));
-		john.setAge(100);
-		repository.save(john);
-		customer = repository.findById(id).get();
-		assertThat("customers do not match", customer, equalTo(john));
-	}
+    @Nested
+    @TestPropertySource(properties = "returnOriginalEntities=false")
+    public class JavaRecords {
 
-	@Test
-	public void findAllByIterableTest() {
-		repository.saveAll(customers);
-		ids.add(john.getId());
-		ids.add(bob.getId());
-		final Iterable<Customer> response = repository.findAllById(ids);
-		assertThat("customers do not match", equals(customers, response, cmp, eq, false), equalTo(true));
-	}
+        @Autowired
+        protected UserRecordRepository repository;
 
-	@Test
-	public void findAllTest() {
-		repository.saveAll(customers);
-		final Iterable<Customer> response = repository.findAll();
-		assertThat("customers do not match", equals(customers, response, cmp, eq, false), equalTo(true));
-	}
+        @Test
+        public void saveTest() {
+            UserRecord i = new UserRecord("mike", 22);
+            UserRecord o = repository.save(i);
+            assertThat(o, not(sameInstance(i)));
+            assertThat(o.key(), is(notNullValue()));
+            assertThat(o.id(), is(notNullValue()));
+            assertThat(o.rev(), is(notNullValue()));
+            assertThat(o.name(), equalTo(i.name()));
+            assertThat(o.age(), equalTo(i.age()));
+        }
 
-	@Test
-	public void countTest() {
-		repository.saveAll(customers);
-		final long size = repository.count();
-		assertThat("customer set sizes do not match", customers.size() == size);
-	}
+        @Test
+        public void saveAllTest() {
+            List<UserRecord> i = List.of(
+                    new UserRecord("mike", 22),
+                    new UserRecord("mary", 33)
+            );
+            List<UserRecord> o = Streamable.of(repository.saveAll(i)).toList();
+            assertThat(o, Matchers.hasSize(i.size()));
 
-	@Test
-	public void existsTest() {
-		repository.save(john);
-		assertThat("customer does not exist but should", repository.existsById(john.getId()), equalTo(true));
-		assertThat("customer exists but should not", repository.existsById(john.getId() + "0"), equalTo(false));
-	}
+            assertThat(o.get(0).key(), is(notNullValue()));
+            assertThat(o.get(0).id(), is(notNullValue()));
+            assertThat(o.get(0).rev(), is(notNullValue()));
+            assertThat(o.get(0).name(), equalTo(i.get(0).name()));
+            assertThat(o.get(0).age(), equalTo(i.get(0).age()));
 
-	@Test
-	public void deleteByEntityTest() {
-		repository.saveAll(customers);
-		final String johnId = john.getId();
-		repository.delete(john);
-		assertThat(repository.existsById(bob.getId()), equalTo(true));
-		assertThat(repository.existsById(johnId), equalTo(false));
-	}
+            assertThat(o.get(1).key(), is(notNullValue()));
+            assertThat(o.get(1).id(), is(notNullValue()));
+            assertThat(o.get(1).rev(), is(notNullValue()));
+            assertThat(o.get(1).name(), equalTo(i.get(1).name()));
+            assertThat(o.get(1).age(), equalTo(i.get(1).age()));
+        }
+    }
 
-	@Test
-	public void deleteByIdTest() {
-		repository.saveAll(customers);
-		final String johnId = john.getId();
-		repository.deleteById(johnId);
-		assertThat(repository.existsById(bob.getId()), equalTo(true));
-		assertThat(repository.existsById(johnId), equalTo(false));
-	}
+    @Test
+    public void findOneTest() {
+        repository.save(john);
+        final String id = john.getId();
+        Customer customer = repository.findById(id).get();
+        assertThat("customers do not match", customer, equalTo(john));
+        john.setAge(100);
+        repository.save(john);
+        customer = repository.findById(id).get();
+        assertThat("customers do not match", customer, equalTo(john));
+    }
 
-	@Test
-	public void deleteAllByIdTest() {
-		repository.saveAll(customers);
-		final String johnId = john.getId();
-		final String bobId = bob.getId();
-		repository.deleteAllById(Arrays.asList(johnId, bobId));
-		assertThat(repository.existsById(bobId), equalTo(false));
-		assertThat(repository.existsById(johnId), equalTo(false));
-	}
+    @Test
+    public void findAllByIterableTest() {
+        repository.saveAll(customers);
+        ids.add(john.getId());
+        ids.add(bob.getId());
+        final Iterable<Customer> response = repository.findAllById(ids);
+        assertThat("customers do not match", equals(customers, response, cmp, eq, false), equalTo(true));
+    }
 
-	@Test
-	public void deleteByIterableTest() {
-		repository.saveAll(customers);
-		final List<Customer> toDelete = new ArrayList<>();
-		toDelete.add(john);
-		final String johnId = john.getId();
-		repository.deleteAll(toDelete);
-		assertThat(repository.existsById(bob.getId()), equalTo(true));
-		assertThat(repository.existsById(johnId), equalTo(false));
-	}
+    @Test
+    public void findAllTest() {
+        repository.saveAll(customers);
+        final Iterable<Customer> response = repository.findAll();
+        assertThat("customers do not match", equals(customers, response, cmp, eq, false), equalTo(true));
+    }
 
-	@Test
-	public void deleteAllTest() {
-		repository.saveAll(customers);
-		repository.deleteAll();
-		assertThat(repository.count(), equalTo(0L));
-	}
+    @Test
+    public void countTest() {
+        repository.saveAll(customers);
+        final long size = repository.count();
+        assertThat("customer set sizes do not match", customers.size() == size);
+    }
 
-	@Test
-	public void findAllSortTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "C", 0));
-		toBeRetrieved.add(new Customer("B", "D", 0));
-		repository.saveAll(toBeRetrieved);
-		final List<Sort.Order> orders = new LinkedList<>();
-		orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
-		orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
-		final Sort sort = Sort.by(orders);
-		final Iterable<Customer> retrieved = repository.findAll(sort);
-		assertThat(equals(toBeRetrieved, retrieved, cmp, eq, true), equalTo(true));
-	}
+    @Test
+    public void existsTest() {
+        repository.save(john);
+        assertThat("customer does not exist but should", repository.existsById(john.getId()), equalTo(true));
+        assertThat("customer exists but should not", repository.existsById(john.getId() + "0"), equalTo(false));
+    }
 
-	@Test
-	public void findAllPageableTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "X", 0));
-		toBeRetrieved.add(new Customer("B", "Y", 0));
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		toBeRetrieved.add(new Customer("D", "T", 0));
-		toBeRetrieved.add(new Customer("D", "U", 0));
-		toBeRetrieved.add(new Customer("E", "S", 0));
-		toBeRetrieved.add(new Customer("F", "P", 0));
-		toBeRetrieved.add(new Customer("F", "Q", 0));
-		toBeRetrieved.add(new Customer("F", "R", 0));
-		repository.saveAll(toBeRetrieved);
-		final List<Sort.Order> orders = new LinkedList<>();
-		orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
-		orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
-		final Sort sort = Sort.by(orders);
-		final int pageNumber = 1;
-		final int pageSize = 3;
-		final Page<Customer> retrievedPage = repository.findAll(PageRequest.of(pageNumber, pageSize, sort));
-		assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
-		assertThat(retrievedPage.getNumber(), equalTo(pageNumber));
-		assertThat(retrievedPage.getSize(), equalTo(pageSize));
-		assertThat(retrievedPage.getTotalPages(), equalTo((toBeRetrieved.size() + pageSize - 1) / pageSize));
-		final List<Customer> expected = toBeRetrieved.subList(pageNumber * pageSize, (pageNumber + 1) * pageSize);
-		assertThat(equals(expected, retrievedPage, cmp, eq, true), equalTo(true));
-	}
+    @Test
+    public void deleteByEntityTest() {
+        repository.saveAll(customers);
+        final String johnId = john.getId();
+        repository.delete(john);
+        assertThat(repository.existsById(bob.getId()), equalTo(true));
+        assertThat(repository.existsById(johnId), equalTo(false));
+    }
 
-	@Test
-	public void findOneByExampleTest() {
-		repository.save(john);
-		final Customer customer = repository.findOne(Example.of(john)).get();
-		assertThat("customers do not match", customer, equalTo(john));
-	}
+    @Test
+    public void deleteByIdTest() {
+        repository.saveAll(customers);
+        final String johnId = john.getId();
+        repository.deleteById(johnId);
+        assertThat(repository.existsById(bob.getId()), equalTo(true));
+        assertThat(repository.existsById(johnId), equalTo(false));
+    }
 
-	@Test
-	public void findAllByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check1 = new Customer("B", "X", 0);
-		final Customer check2 = new Customer("B", "Y", 0);
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(check1);
-		toBeRetrieved.add(check2);
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		repository.saveAll(toBeRetrieved);
-		final Example<Customer> example = Example.of(new Customer("B", null, 0));
-		final Iterable<?> retrieved = repository.findAll(example);
-		final List<Customer> retrievedList = new LinkedList<>();
-		retrieved.forEach(e -> retrievedList.add((Customer) e));
-		final List<Customer> checkList = new LinkedList<>();
-		checkList.add(check1);
-		checkList.add(check2);
-		assertThat(equals(checkList, retrievedList, cmp, eq, false), equalTo(true));
-	}
+    @Test
+    public void deleteAllByIdTest() {
+        repository.saveAll(customers);
+        final String johnId = john.getId();
+        final String bobId = bob.getId();
+        repository.deleteAllById(Arrays.asList(johnId, bobId));
+        assertThat(repository.existsById(bobId), equalTo(false));
+        assertThat(repository.existsById(johnId), equalTo(false));
+    }
 
-	@Test
-	public void findAllByExampleRegexTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check1 = new Customer("B", "X", 0);
-		final Customer check2 = new Customer("B", "Y", 0);
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(check1);
-		toBeRetrieved.add(check2);
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		repository.saveAll(toBeRetrieved);
-		Customer find = new Customer("([B])", null, 0);
-		ExampleMatcher exampleMatcher = ExampleMatcher.matching().withIgnoreNullValues().withMatcher("name",
-				ExampleMatcher.GenericPropertyMatcher::regex);
-		final Example<Customer> example = Example.of(find, exampleMatcher);
-		final Iterable<?> retrieved = repository.findAll(example);
-		final List<Customer> retrievedList = new LinkedList<>();
-		retrieved.forEach(e -> retrievedList.add((Customer) e));
-		final List<Customer> checkList = new LinkedList<>();
-		checkList.add(check1);
-		checkList.add(check2);
-		assertThat(equals(checkList, retrievedList, cmp, eq, false), equalTo(true));
-	}
+    @Test
+    public void deleteByIterableTest() {
+        repository.saveAll(customers);
+        final List<Customer> toDelete = new ArrayList<>();
+        toDelete.add(john);
+        final String johnId = john.getId();
+        repository.deleteAll(toDelete);
+        assertThat(repository.existsById(bob.getId()), equalTo(true));
+        assertThat(repository.existsById(johnId), equalTo(false));
+    }
 
-	@Test
-	public void findAllSortByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "C", 0));
-		toBeRetrieved.add(new Customer("B", "D", 0));
-		repository.saveAll(toBeRetrieved);
-		repository.save(new Customer("A", "A", 1));
-		final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
-				.withIgnoreNullValues().withIgnorePaths("location", "alive"));
-		final List<Sort.Order> orders = new LinkedList<>();
-		orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
-		orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
-		final Sort sort = Sort.by(orders);
-		final Iterable<Customer> retrieved = repository.findAll(example, sort);
-		assertThat(equals(toBeRetrieved, retrieved, cmp, eq, true), equalTo(true));
-	}
+    @Test
+    public void deleteAllTest() {
+        repository.saveAll(customers);
+        repository.deleteAll();
+        assertThat(repository.count(), equalTo(0L));
+    }
 
-	@Test
-	public void findAllPageableByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "X", 0));
-		toBeRetrieved.add(new Customer("B", "Y", 0));
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		toBeRetrieved.add(new Customer("D", "T", 0));
-		toBeRetrieved.add(new Customer("D", "U", 0));
-		toBeRetrieved.add(new Customer("E", "S", 0));
-		toBeRetrieved.add(new Customer("F", "P", 0));
-		toBeRetrieved.add(new Customer("F", "Q", 0));
-		toBeRetrieved.add(new Customer("F", "R", 0));
-		repository.saveAll(toBeRetrieved);
-		repository.save(new Customer("A", "A", 1));
-		final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
-				.withIgnoreNullValues().withIgnorePaths("location", "alive"));
-		final List<Sort.Order> orders = new LinkedList<>();
-		orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
-		orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
-		final Sort sort = Sort.by(orders);
-		final int pageNumber = 1;
-		final int pageSize = 3;
-		final Page<Customer> retrievedPage = repository.findAll(example, PageRequest.of(pageNumber, pageSize, sort));
-		assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
-		assertThat(retrievedPage.getNumber(), equalTo(pageNumber));
-		assertThat(retrievedPage.getSize(), equalTo(pageSize));
-		assertThat(retrievedPage.getTotalPages(), equalTo((toBeRetrieved.size() + pageSize - 1) / pageSize));
-		final List<Customer> expected = toBeRetrieved.subList(pageNumber * pageSize, (pageNumber + 1) * pageSize);
-		assertThat(equals(expected, retrievedPage, cmp, eq, true), equalTo(true));
-	}
+    @Test
+    public void findAllSortTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "C", 0));
+        toBeRetrieved.add(new Customer("B", "D", 0));
+        repository.saveAll(toBeRetrieved);
+        final List<Sort.Order> orders = new LinkedList<>();
+        orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
+        orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
+        final Sort sort = Sort.by(orders);
+        final Iterable<Customer> retrieved = repository.findAll(sort);
+        assertThat(equals(toBeRetrieved, retrieved, cmp, eq, true), equalTo(true));
+    }
 
-	@Test
-	public void countByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "X", 0));
-		toBeRetrieved.add(new Customer("B", "Y", 0));
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		toBeRetrieved.add(new Customer("D", "T", 0));
-		toBeRetrieved.add(new Customer("D", "U", 0));
-		toBeRetrieved.add(new Customer("E", "S", 0));
-		toBeRetrieved.add(new Customer("F", "P", 0));
-		toBeRetrieved.add(new Customer("F", "Q", 0));
-		toBeRetrieved.add(new Customer("F", "R", 0));
-		repository.saveAll(toBeRetrieved);
-		final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
-				.withIgnoreNullValues().withIgnorePaths("location", "alive"));
-		final long size = repository.count(example);
-		assertThat(size == toBeRetrieved.size(), equalTo(true));
-	}
+    @Test
+    public void findAllPageableTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "X", 0));
+        toBeRetrieved.add(new Customer("B", "Y", 0));
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        toBeRetrieved.add(new Customer("D", "T", 0));
+        toBeRetrieved.add(new Customer("D", "U", 0));
+        toBeRetrieved.add(new Customer("E", "S", 0));
+        toBeRetrieved.add(new Customer("F", "P", 0));
+        toBeRetrieved.add(new Customer("F", "Q", 0));
+        toBeRetrieved.add(new Customer("F", "R", 0));
+        repository.saveAll(toBeRetrieved);
+        final List<Sort.Order> orders = new LinkedList<>();
+        orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
+        orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
+        final Sort sort = Sort.by(orders);
+        final int pageNumber = 1;
+        final int pageSize = 3;
+        final Page<Customer> retrievedPage = repository.findAll(PageRequest.of(pageNumber, pageSize, sort));
+        assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
+        assertThat(retrievedPage.getNumber(), equalTo(pageNumber));
+        assertThat(retrievedPage.getSize(), equalTo(pageSize));
+        assertThat(retrievedPage.getTotalPages(), equalTo((toBeRetrieved.size() + pageSize - 1) / pageSize));
+        final List<Customer> expected = toBeRetrieved.subList(pageNumber * pageSize, (pageNumber + 1) * pageSize);
+        assertThat(equals(expected, retrievedPage, cmp, eq, true), equalTo(true));
+    }
 
-	@Test
-	public void existsByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer checker = new Customer("I", "Exist", 25, true);
-		toBeRetrieved.add(new Customer("A", "Z", 0));
-		toBeRetrieved.add(new Customer("B", "X", 0));
-		toBeRetrieved.add(new Customer("B", "Y", 0));
-		toBeRetrieved.add(new Customer("C", "V", 0));
-		toBeRetrieved.add(checker);
-		repository.saveAll(toBeRetrieved);
-		final Example<Customer> example = Example.of(checker);
-		final boolean exists = repository.exists(example);
-		assertThat(exists, equalTo(true));
-	}
+    @Test
+    public void findOneByExampleTest() {
+        repository.save(john);
+        final Customer customer = repository.findOne(Example.of(john)).get();
+        assertThat("customers do not match", customer, equalTo(john));
+    }
 
-	@Test
-	public void startingWithByExampleTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("Baabba", "", 67));
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Example<Customer> example = Example.of(new Customer(null, "bb", 100), ExampleMatcher.matching()
-				.withMatcher("surname", ExampleMatcher.GenericPropertyMatcher::startsWith).withIgnoreCase("surname").withIgnoreNullValues());
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
-	
-	@Test
-	public void findAllByExampleWithArrayTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
-		final Customer nested2 = new Customer("qwerty", "", 10);
-		check.setNestedCustomers(Arrays.asList(nested, nested2));
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("Baabba", "", 67));
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
-		final Customer exampleNested = new Customer("Bwa?[a.b]baAa", "", 67);
-		exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested));
-		final Example<Customer> example = Example.of(exampleCustomer);
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
+    @Test
+    public void findAllByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check1 = new Customer("B", "X", 0);
+        final Customer check2 = new Customer("B", "Y", 0);
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(check1);
+        toBeRetrieved.add(check2);
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        repository.saveAll(toBeRetrieved);
+        final Example<Customer> example = Example.of(new Customer("B", null, 0));
+        final Iterable<?> retrieved = repository.findAll(example);
+        final List<Customer> retrievedList = new LinkedList<>();
+        retrieved.forEach(e -> retrievedList.add((Customer) e));
+        final List<Customer> checkList = new LinkedList<>();
+        checkList.add(check1);
+        checkList.add(check2);
+        assertThat(equals(checkList, retrievedList, cmp, eq, false), equalTo(true));
+    }
 
-	@Test
-	public void findAllByExampleWithArray2Test() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
-		final Customer nested2 = new Customer("qwertyASD", "", 10);
-		check.setNestedCustomers(Arrays.asList(nested, nested2));
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("Baabba", "", 67));
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer();
-		final Customer exampleNested = new Customer("qwertyASD", "", 10);
-		exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested));
-		final Example<Customer> example = Example.of(exampleCustomer, ExampleMatcher.matching()
-				.withIgnoreNullValues().withIgnorePaths("location", "alive", "age"));
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
-	
-	@Test
-	public void findAllByExampleWithArrayORTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
-		final Customer nested2 = new Customer("qwertyASD", "", 10);
-		check.setNestedCustomers(Arrays.asList(nested, nested2));
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("Baabba", "", 67));
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer();
-		final Customer exampleNested = new Customer("qwertyASD", "", 10);
-		final Customer exampleOr = new Customer("qwertyOr", "", 10);
-		exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested, exampleOr));
-		final Example<Customer> example = Example.of(exampleCustomer, ExampleMatcher.matching()
-				.withIgnoreNullValues().withIgnorePaths("location", "alive", "age"));
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
+    @Test
+    public void findAllByExampleRegexTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check1 = new Customer("B", "X", 0);
+        final Customer check2 = new Customer("B", "Y", 0);
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(check1);
+        toBeRetrieved.add(check2);
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        repository.saveAll(toBeRetrieved);
+        Customer find = new Customer("([B])", null, 0);
+        ExampleMatcher exampleMatcher = ExampleMatcher.matching().withIgnoreNullValues().withMatcher("name",
+                ExampleMatcher.GenericPropertyMatcher::regex);
+        final Example<Customer> example = Example.of(find, exampleMatcher);
+        final Iterable<?> retrieved = repository.findAll(example);
+        final List<Customer> retrievedList = new LinkedList<>();
+        retrieved.forEach(e -> retrievedList.add((Customer) e));
+        final List<Customer> checkList = new LinkedList<>();
+        checkList.add(check1);
+        checkList.add(check2);
+        assertThat(equals(checkList, retrievedList, cmp, eq, false), equalTo(true));
+    }
 
-	@Test
-	public void findAllByExampleWhitArrayStringTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer customer1 = new Customer("AbbaXP", "BbaaaaXZ", 1001);
-		final Customer customer2 = new Customer("Bwa?[a.b]baAaGH", "", 67);
-		customer1.setStringList(Arrays.asList("testA", "testB", "testC"));
-		customer2.setStringList(Arrays.asList("test1", "test2", "test3"));
-		toBeRetrieved.add(customer1);
-		toBeRetrieved.add(customer2);
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer("AbbaXP", "BbaaaaXZ", 1001);
-		exampleCustomer.setStringList(Arrays.asList("testB"));
-		final Example<Customer> example = Example.of(exampleCustomer);
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(customer1));
-	}
-	
+    @Test
+    public void findAllSortByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "C", 0));
+        toBeRetrieved.add(new Customer("B", "D", 0));
+        repository.saveAll(toBeRetrieved);
+        repository.save(new Customer("A", "A", 1));
+        final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
+                .withIgnoreNullValues().withIgnorePaths("location", "alive"));
+        final List<Sort.Order> orders = new LinkedList<>();
+        orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
+        orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
+        final Sort sort = Sort.by(orders);
+        final Iterable<Customer> retrieved = repository.findAll(example, sort);
+        assertThat(equals(toBeRetrieved, retrieved, cmp, eq, true), equalTo(true));
+    }
 
-	@Test
-	public void endingWithByExampleNestedTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested = new Customer("$B*\\wa?[a.b]baaa", "", 67);
-		final Customer nested2 = new Customer("qwerty", "", 10);
-		nested2.setAddress(new Address("123456"));
-		nested.setNestedCustomer(nested2);
-		check.setNestedCustomer(nested);
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested3 = new Customer("B*\\wa?[a.b]baAa", null, 66);
-		nested3.setNestedCustomer(nested2);
-		exampleCustomer.setNestedCustomer(nested3);
-		final Example<Customer> example = Example.of(exampleCustomer,
-				ExampleMatcher.matching().withMatcher("nestedCustomer.name", ExampleMatcher.GenericPropertyMatcher::endsWith)
-						.withIgnoreCase("nestedCustomer.name").withIgnoreNullValues().withTransformer(
-								"nestedCustomer.age", o -> Optional.of(Integer.parseInt(o.get().toString()) + 1)));
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
+    @Test
+    public void findAllPageableByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "X", 0));
+        toBeRetrieved.add(new Customer("B", "Y", 0));
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        toBeRetrieved.add(new Customer("D", "T", 0));
+        toBeRetrieved.add(new Customer("D", "U", 0));
+        toBeRetrieved.add(new Customer("E", "S", 0));
+        toBeRetrieved.add(new Customer("F", "P", 0));
+        toBeRetrieved.add(new Customer("F", "Q", 0));
+        toBeRetrieved.add(new Customer("F", "R", 0));
+        repository.saveAll(toBeRetrieved);
+        repository.save(new Customer("A", "A", 1));
+        final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
+                .withIgnoreNullValues().withIgnorePaths("location", "alive"));
+        final List<Sort.Order> orders = new LinkedList<>();
+        orders.add(new Sort.Order(Sort.Direction.ASC, "name"));
+        orders.add(new Sort.Order(Sort.Direction.ASC, "surname"));
+        final Sort sort = Sort.by(orders);
+        final int pageNumber = 1;
+        final int pageSize = 3;
+        final Page<Customer> retrievedPage = repository.findAll(example, PageRequest.of(pageNumber, pageSize, sort));
+        assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
+        assertThat(retrievedPage.getNumber(), equalTo(pageNumber));
+        assertThat(retrievedPage.getSize(), equalTo(pageSize));
+        assertThat(retrievedPage.getTotalPages(), equalTo((toBeRetrieved.size() + pageSize - 1) / pageSize));
+        final List<Customer> expected = toBeRetrieved.subList(pageNumber * pageSize, (pageNumber + 1) * pageSize);
+        assertThat(equals(expected, retrievedPage, cmp, eq, true), equalTo(true));
+    }
 
-	@Test
-	public void endingWithByExampleNestedIncludeNullTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		final Customer check = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested = new Customer("$B*\\wa?[a.b]baaa", "", 67);
-		final Customer nested2 = new Customer("qwerty", "", 10);
-		nested2.setAddress(new Address("123456"));
-		nested.setNestedCustomer(nested2);
-		check.setNestedCustomer(nested);
-		toBeRetrieved.add(check);
-		toBeRetrieved.add(new Customer("B", "", 43));
-		toBeRetrieved.add(new Customer("C", "", 76));
-		repository.saveAll(toBeRetrieved);
-		final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
-		final Customer nested3 = new Customer("B*\\wa?[a.b]baAa", "", 66);
-		nested3.setNestedCustomer(nested2);
-		exampleCustomer.setNestedCustomer(nested3);
-		final Example<Customer> example = Example.of(exampleCustomer,
-				ExampleMatcher.matching().withMatcher("nestedCustomer.name", ExampleMatcher.GenericPropertyMatcher::endsWith)
-						.withIgnorePaths("arangoId", "id", "key", "rev")
-						.withIgnoreCase("nestedCustomer.name").withIncludeNullValues().withTransformer(
-								"nestedCustomer.age", o -> Optional.of(Integer.parseInt(o.get().toString()) + 1)));
-		final Customer retrieved = repository.findOne(example).get();
-		assertThat(retrieved, equalTo(check));
-	}
+    @Test
+    public void countByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "X", 0));
+        toBeRetrieved.add(new Customer("B", "Y", 0));
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        toBeRetrieved.add(new Customer("D", "T", 0));
+        toBeRetrieved.add(new Customer("D", "U", 0));
+        toBeRetrieved.add(new Customer("E", "S", 0));
+        toBeRetrieved.add(new Customer("F", "P", 0));
+        toBeRetrieved.add(new Customer("F", "Q", 0));
+        toBeRetrieved.add(new Customer("F", "R", 0));
+        repository.saveAll(toBeRetrieved);
+        final Example<Customer> example = Example.of(new Customer("", "", 0), ExampleMatcher.matchingAny()
+                .withIgnoreNullValues().withIgnorePaths("location", "alive"));
+        final long size = repository.count(example);
+        assertThat(size == toBeRetrieved.size(), equalTo(true));
+    }
 
-	@Test
-	public void containingExampleTest() {
-		final Customer entity = new Customer("name", "surname", 10);
-		repository.save(entity);
+    @Test
+    public void existsByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer checker = new Customer("I", "Exist", 25, true);
+        toBeRetrieved.add(new Customer("A", "Z", 0));
+        toBeRetrieved.add(new Customer("B", "X", 0));
+        toBeRetrieved.add(new Customer("B", "Y", 0));
+        toBeRetrieved.add(new Customer("C", "V", 0));
+        toBeRetrieved.add(checker);
+        repository.saveAll(toBeRetrieved);
+        final Example<Customer> example = Example.of(checker);
+        final boolean exists = repository.exists(example);
+        assertThat(exists, equalTo(true));
+    }
 
-		final Customer probe = new Customer();
-		probe.setName("am");
-		final Example<Customer> example = Example.of(probe,
-				ExampleMatcher.matching().withStringMatcher(StringMatcher.CONTAINING).withIgnorePaths("arangoId", "id",
-						"key", "rev", "surname", "age"));
-		final Optional<Customer> retrieved = repository.findOne(example);
-		assertThat(retrieved.isPresent(), is(true));
-		assertThat(retrieved.get().getName(), is("name"));
-	}
+    @Test
+    public void startingWithByExampleTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("Baabba", "", 67));
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Example<Customer> example = Example.of(new Customer(null, "bb", 100), ExampleMatcher.matching()
+                .withMatcher("surname", ExampleMatcher.GenericPropertyMatcher::startsWith).withIgnoreCase("surname").withIgnoreNullValues());
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-	@Test
-	public void plusSignExampleTest() {
-		String NAME = "Abc+Def";
-		final Customer entity = new Customer(NAME, "surname", 10);
-		repository.save(entity);
+    @Test
+    public void findAllByExampleWithArrayTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
+        final Customer nested2 = new Customer("qwerty", "", 10);
+        check.setNestedCustomers(Arrays.asList(nested, nested2));
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("Baabba", "", 67));
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
+        final Customer exampleNested = new Customer("Bwa?[a.b]baAa", "", 67);
+        exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested));
+        final Example<Customer> example = Example.of(exampleCustomer);
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-		final Customer probe = new Customer();
-		probe.setName(NAME);
-		probe.setAge(10);
-		final Example<Customer> example = Example.of(probe);
-		final Optional<Customer> retrieved = repository.findOne(example);
-		assertThat(retrieved.isPresent(), is(true));
-		assertThat(retrieved.get().getName(), is(NAME));
-	}
+    @Test
+    public void findAllByExampleWithArray2Test() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
+        final Customer nested2 = new Customer("qwertyASD", "", 10);
+        check.setNestedCustomers(Arrays.asList(nested, nested2));
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("Baabba", "", 67));
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer();
+        final Customer exampleNested = new Customer("qwertyASD", "", 10);
+        exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested));
+        final Example<Customer> example = Example.of(exampleCustomer, ExampleMatcher.matching()
+                .withIgnoreNullValues().withIgnorePaths("location", "alive", "age"));
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-	@Test
-	public void exampleWithLikeAndEscapingTest() {
-		String NAME = "Abc+Def";
-		final Customer entity = new Customer(NAME, "surname", 10);
-		repository.save(entity);
+    @Test
+    public void findAllByExampleWithArrayORTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested = new Customer("Bwa?[a.b]baAa", "", 67);
+        final Customer nested2 = new Customer("qwertyASD", "", 10);
+        check.setNestedCustomers(Arrays.asList(nested, nested2));
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("Baabba", "", 67));
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer();
+        final Customer exampleNested = new Customer("qwertyASD", "", 10);
+        final Customer exampleOr = new Customer("qwertyOr", "", 10);
+        exampleCustomer.setNestedCustomers(Arrays.asList(exampleNested, exampleOr));
+        final Example<Customer> example = Example.of(exampleCustomer, ExampleMatcher.matching()
+                .withIgnoreNullValues().withIgnorePaths("location", "alive", "age"));
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-		final Customer probe = new Customer();
-		probe.setName("Abc+De%");
-		probe.setAge(10);
-		final Example<Customer> example = Example.of(probe);
-		final Optional<Customer> retrieved = repository.findOne(example);
-		assertThat(retrieved.isPresent(), is(false));
-	}
+    @Test
+    public void findAllByExampleWhitArrayStringTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer customer1 = new Customer("AbbaXP", "BbaaaaXZ", 1001);
+        final Customer customer2 = new Customer("Bwa?[a.b]baAaGH", "", 67);
+        customer1.setStringList(Arrays.asList("testA", "testB", "testC"));
+        customer2.setStringList(Arrays.asList("test1", "test2", "test3"));
+        toBeRetrieved.add(customer1);
+        toBeRetrieved.add(customer2);
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer("AbbaXP", "BbaaaaXZ", 1001);
+        exampleCustomer.setStringList(Arrays.asList("testB"));
+        final Example<Customer> example = Example.of(exampleCustomer);
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(customer1));
+    }
 
-	@Test
-	public void exampleWithRefPropertyTest() {
 
-		ShoppingCart shoppingCart = new ShoppingCart();
-		shoppingCartRepository.save(shoppingCart);
+    @Test
+    public void endingWithByExampleNestedTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested = new Customer("$B*\\wa?[a.b]baaa", "", 67);
+        final Customer nested2 = new Customer("qwerty", "", 10);
+        nested2.setAddress(new Address("123456"));
+        nested.setNestedCustomer(nested2);
+        check.setNestedCustomer(nested);
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested3 = new Customer("B*\\wa?[a.b]baAa", null, 66);
+        nested3.setNestedCustomer(nested2);
+        exampleCustomer.setNestedCustomer(nested3);
+        final Example<Customer> example = Example.of(exampleCustomer,
+                ExampleMatcher.matching().withMatcher("nestedCustomer.name", ExampleMatcher.GenericPropertyMatcher::endsWith)
+                        .withIgnoreCase("nestedCustomer.name").withIgnoreNullValues().withTransformer(
+                                "nestedCustomer.age", o -> Optional.of(Integer.parseInt(o.get().toString()) + 1)));
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-		Customer customer = new Customer("Dhiren", "Upadhyay", 28);
-		customer.setShoppingCart(shoppingCart);
-		repository.save(customer);
+    @Test
+    public void endingWithByExampleNestedIncludeNullTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        final Customer check = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested = new Customer("$B*\\wa?[a.b]baaa", "", 67);
+        final Customer nested2 = new Customer("qwerty", "", 10);
+        nested2.setAddress(new Address("123456"));
+        nested.setNestedCustomer(nested2);
+        check.setNestedCustomer(nested);
+        toBeRetrieved.add(check);
+        toBeRetrieved.add(new Customer("B", "", 43));
+        toBeRetrieved.add(new Customer("C", "", 76));
+        repository.saveAll(toBeRetrieved);
+        final Customer exampleCustomer = new Customer("Abba", "Bbaaaa", 100);
+        final Customer nested3 = new Customer("B*\\wa?[a.b]baAa", "", 66);
+        nested3.setNestedCustomer(nested2);
+        exampleCustomer.setNestedCustomer(nested3);
+        final Example<Customer> example = Example.of(exampleCustomer,
+                ExampleMatcher.matching().withMatcher("nestedCustomer.name", ExampleMatcher.GenericPropertyMatcher::endsWith)
+                        .withIgnorePaths("arangoId", "id", "key", "rev")
+                        .withIgnoreCase("nestedCustomer.name").withIncludeNullValues().withTransformer(
+                                "nestedCustomer.age", o -> Optional.of(Integer.parseInt(o.get().toString()) + 1)));
+        final Customer retrieved = repository.findOne(example).get();
+        assertThat(retrieved, equalTo(check));
+    }
 
-		Customer customer1 = new Customer();
-		customer1.setShoppingCart(shoppingCart);
-		ExampleMatcher exampleMatcher = ExampleMatcher.matching().withIgnorePaths("age", "location", "alive");
-		Example<Customer> example = Example.of(customer1, exampleMatcher);
+    @Test
+    public void containingExampleTest() {
+        final Customer entity = new Customer("name", "surname", 10);
+        repository.save(entity);
 
-		final Customer retrieved = repository.findOne(example).orElse(null);
-		assertThat(retrieved, equalTo(customer));
-	}
+        final Customer probe = new Customer();
+        probe.setName("am");
+        final Example<Customer> example = Example.of(probe,
+                ExampleMatcher.matching().withStringMatcher(StringMatcher.CONTAINING).withIgnorePaths("arangoId", "id",
+                        "key", "rev", "surname", "age"));
+        final Optional<Customer> retrieved = repository.findOne(example);
+        assertThat(retrieved.isPresent(), is(true));
+        assertThat(retrieved.get().getName(), is("name"));
+    }
 
-	@Test
-	public void findAllUnpagedPageableTest() {
-		final List<Customer> toBeRetrieved = new LinkedList<>();
-		toBeRetrieved.add(new Customer("Dhiren", "Upadhyay", 30));
-		toBeRetrieved.add(new Customer("Ashim", "Upadhyay", 28));
-		toBeRetrieved.add(new Customer("Lokendr", "Upadhyay", 24));
-		repository.saveAll(toBeRetrieved);
-		final Page<Customer> retrievedPage = repository.findAll(Pageable.unpaged());
-		assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
-		assertThat(retrievedPage.getSize(), equalTo(toBeRetrieved.size()));
-		assertThat(retrievedPage.getContent(), equalTo(toBeRetrieved));
-	}
+    @Test
+    public void plusSignExampleTest() {
+        String NAME = "Abc+Def";
+        final Customer entity = new Customer(NAME, "surname", 10);
+        repository.save(entity);
+
+        final Customer probe = new Customer();
+        probe.setName(NAME);
+        probe.setAge(10);
+        final Example<Customer> example = Example.of(probe);
+        final Optional<Customer> retrieved = repository.findOne(example);
+        assertThat(retrieved.isPresent(), is(true));
+        assertThat(retrieved.get().getName(), is(NAME));
+    }
+
+    @Test
+    public void exampleWithLikeAndEscapingTest() {
+        String NAME = "Abc+Def";
+        final Customer entity = new Customer(NAME, "surname", 10);
+        repository.save(entity);
+
+        final Customer probe = new Customer();
+        probe.setName("Abc+De%");
+        probe.setAge(10);
+        final Example<Customer> example = Example.of(probe);
+        final Optional<Customer> retrieved = repository.findOne(example);
+        assertThat(retrieved.isPresent(), is(false));
+    }
+
+    @Test
+    public void exampleWithRefPropertyTest() {
+
+        ShoppingCart shoppingCart = new ShoppingCart();
+        shoppingCartRepository.save(shoppingCart);
+
+        Customer customer = new Customer("Dhiren", "Upadhyay", 28);
+        customer.setShoppingCart(shoppingCart);
+        repository.save(customer);
+
+        Customer customer1 = new Customer();
+        customer1.setShoppingCart(shoppingCart);
+        ExampleMatcher exampleMatcher = ExampleMatcher.matching().withIgnorePaths("age", "location", "alive");
+        Example<Customer> example = Example.of(customer1, exampleMatcher);
+
+        final Customer retrieved = repository.findOne(example).orElse(null);
+        assertThat(retrieved, equalTo(customer));
+    }
+
+    @Test
+    public void findAllUnpagedPageableTest() {
+        final List<Customer> toBeRetrieved = new LinkedList<>();
+        toBeRetrieved.add(new Customer("Dhiren", "Upadhyay", 30));
+        toBeRetrieved.add(new Customer("Ashim", "Upadhyay", 28));
+        toBeRetrieved.add(new Customer("Lokendr", "Upadhyay", 24));
+        repository.saveAll(toBeRetrieved);
+        final Page<Customer> retrievedPage = repository.findAll(Pageable.unpaged());
+        assertThat(retrievedPage.getTotalElements(), equalTo((long) toBeRetrieved.size()));
+        assertThat(retrievedPage.getSize(), equalTo(toBeRetrieved.size()));
+        assertThat(retrievedPage.getContent(), equalTo(toBeRetrieved));
+    }
 
 }

--- a/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
+++ b/src/test/java/com/arangodb/springframework/repository/ArangoRepositoryTest.java
@@ -4,6 +4,7 @@ import com.arangodb.springframework.testdata.Address;
 import com.arangodb.springframework.testdata.Customer;
 import com.arangodb.springframework.testdata.ShoppingCart;
 import com.arangodb.springframework.testdata.UserRecord;
+import com.arangodb.springframework.testdata.UserImmutable;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -120,6 +121,48 @@ public class ArangoRepositoryTest extends AbstractArangoRepositoryTest {
             assertThat(o.get(1).rev(), is(notNullValue()));
             assertThat(o.get(1).name(), equalTo(i.get(1).name()));
             assertThat(o.get(1).age(), equalTo(i.get(1).age()));
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "returnOriginalEntities=false")
+    public class ImmutableEntity {
+
+        @Autowired
+        protected UserImmutableRepository repository;
+
+        @Test
+        public void saveTest() {
+            UserImmutable i = new UserImmutable("mike", 22);
+            UserImmutable o = repository.save(i);
+            assertThat(o, not(sameInstance(i)));
+            assertThat(o.getKey(), is(notNullValue()));
+            assertThat(o.getId(), is(notNullValue()));
+            assertThat(o.getRev(), is(notNullValue()));
+            assertThat(o.getName(), equalTo(i.getName()));
+            assertThat(o.getAge(), equalTo(i.getAge()));
+        }
+
+        @Test
+        public void saveAllTest() {
+            List<UserImmutable> i = List.of(
+                    new UserImmutable("mike", 22),
+                    new UserImmutable("mary", 33)
+            );
+            List<UserImmutable> o = Streamable.of(repository.saveAll(i)).toList();
+            assertThat(o, Matchers.hasSize(i.size()));
+
+            assertThat(o.get(0).getKey(), is(notNullValue()));
+            assertThat(o.get(0).getId(), is(notNullValue()));
+            assertThat(o.get(0).getRev(), is(notNullValue()));
+            assertThat(o.get(0).getName(), equalTo(i.get(0).getName()));
+            assertThat(o.get(0).getAge(), equalTo(i.get(0).getAge()));
+
+            assertThat(o.get(1).getKey(), is(notNullValue()));
+            assertThat(o.get(1).getId(), is(notNullValue()));
+            assertThat(o.get(1).getRev(), is(notNullValue()));
+            assertThat(o.get(1).getName(), equalTo(i.get(1).getName()));
+            assertThat(o.get(1).getAge(), equalTo(i.get(1).getAge()));
         }
     }
 

--- a/src/test/java/com/arangodb/springframework/repository/UserImmutableRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/UserImmutableRepository.java
@@ -1,0 +1,7 @@
+package com.arangodb.springframework.repository;
+
+import com.arangodb.springframework.testdata.UserImmutable;
+
+public interface UserImmutableRepository extends ArangoRepository<UserImmutable, String> {
+}
+

--- a/src/test/java/com/arangodb/springframework/repository/UserRecordRepository.java
+++ b/src/test/java/com/arangodb/springframework/repository/UserRecordRepository.java
@@ -1,0 +1,7 @@
+package com.arangodb.springframework.repository;
+
+import com.arangodb.springframework.testdata.UserRecord;
+
+public interface UserRecordRepository extends ArangoRepository<UserRecord, String> {
+}
+

--- a/src/test/java/com/arangodb/springframework/testdata/UserImmutable.java
+++ b/src/test/java/com/arangodb/springframework/testdata/UserImmutable.java
@@ -1,0 +1,80 @@
+package com.arangodb.springframework.testdata;
+
+import com.arangodb.springframework.annotation.ArangoId;
+import com.arangodb.springframework.annotation.Rev;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceCreator;
+
+import java.util.Objects;
+
+public final class UserImmutable {
+    @Id
+    private final String key;
+
+    @ArangoId
+    private final String id;
+
+    @Rev
+    private final String rev;
+
+    private final String name;
+
+    private final int age;
+
+    @PersistenceCreator
+    public UserImmutable(String key, String id, String rev, String name, int age) {
+        this.key = key;
+        this.id = id;
+        this.rev = rev;
+        this.name = name;
+        this.age = age;
+    }
+
+    public UserImmutable(String name, int age) {
+        this(null, null, null, name, age);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getRev() {
+        return rev;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserImmutable that = (UserImmutable) o;
+        return age == that.age && Objects.equals(key, that.key) && Objects.equals(id, that.id) && Objects.equals(rev, that.rev) && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, id, rev, name, age);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableUser{" +
+                "key='" + key + '\'' +
+                ", id='" + id + '\'' +
+                ", rev='" + rev + '\'' +
+                ", name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/src/test/java/com/arangodb/springframework/testdata/UserRecord.java
+++ b/src/test/java/com/arangodb/springframework/testdata/UserRecord.java
@@ -1,0 +1,26 @@
+package com.arangodb.springframework.testdata;
+
+import com.arangodb.springframework.annotation.ArangoId;
+import com.arangodb.springframework.annotation.Document;
+import com.arangodb.springframework.annotation.Rev;
+import org.springframework.data.annotation.Id;
+
+@Document
+public record UserRecord(
+        @Id
+        String key,
+
+        @ArangoId
+        String id,
+
+        @Rev
+        String rev,
+
+        String name,
+
+        int age
+) {
+    public UserRecord(String name, int age) {
+        this(null, null, null, name, age);
+    }
+}


### PR DESCRIPTION
`SimpleArangoRepository.save()` and `saveAll()` can now be configured to return the entity created from the server result instead of the original (#291). As the may lead to unexpected behaviour, the default is using the old behaviour.

The configuration can be done by a `RepositoryFactoryCustomizer`, which can be prepared in an upcoming `spring-boot-starter` version.


---
fixes #291 