### PR TITLE
[DE-780] extend properties annotation targets

### DIFF
--- a/src/main/java/com/arangodb/springframework/annotation/ArangoComputedValue.java
+++ b/src/main/java/com/arangodb/springframework/annotation/ArangoComputedValue.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  * @see <a href="https://docs.arangodb.com/stable/concepts/data-structure/documents/computed-values">Reference Doc</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface ArangoComputedValue {
 
     @AliasFor("expression")

--- a/src/main/java/com/arangodb/springframework/annotation/ArangoId.java
+++ b/src/main/java/com/arangodb/springframework/annotation/ArangoId.java
@@ -34,7 +34,7 @@ import org.springframework.data.annotation.ReadOnlyProperty;
  * @author Mark Vollmary
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @ReadOnlyProperty
 public @interface ArangoId {
 

--- a/src/main/java/com/arangodb/springframework/annotation/Field.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Field.java
@@ -32,12 +32,12 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface Field {
 
-	/**
-	 * The field-name to be used to store the field inside the document.
-	 */
-	String value() default "";
+    /**
+     * The field-name to be used to store the field inside the document.
+     */
+    String value() default "";
 
 }

--- a/src/main/java/com/arangodb/springframework/annotation/From.java
+++ b/src/main/java/com/arangodb/springframework/annotation/From.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface From {
 
 	/**

--- a/src/main/java/com/arangodb/springframework/annotation/FulltextIndexed.java
+++ b/src/main/java/com/arangodb/springframework/annotation/FulltextIndexed.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Deprecated
 public @interface FulltextIndexed {
 

--- a/src/main/java/com/arangodb/springframework/annotation/GeoIndexed.java
+++ b/src/main/java/com/arangodb/springframework/annotation/GeoIndexed.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface GeoIndexed {
 
 	/**

--- a/src/main/java/com/arangodb/springframework/annotation/PersistentIndexed.java
+++ b/src/main/java/com/arangodb/springframework/annotation/PersistentIndexed.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface PersistentIndexed {
 
 	/**

--- a/src/main/java/com/arangodb/springframework/annotation/Ref.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Ref.java
@@ -36,7 +36,7 @@ import org.springframework.data.annotation.Reference;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Reference
 public @interface Ref {
 

--- a/src/main/java/com/arangodb/springframework/annotation/Relations.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Relations.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface Relations {
 
 	public enum Direction {

--- a/src/main/java/com/arangodb/springframework/annotation/Rev.java
+++ b/src/main/java/com/arangodb/springframework/annotation/Rev.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface Rev {
 
 }

--- a/src/main/java/com/arangodb/springframework/annotation/To.java
+++ b/src/main/java/com/arangodb/springframework/annotation/To.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 public @interface To {
 
 	/**


### PR DESCRIPTION
This PR allows setting properties annotation targets to:
- `ElementType.FIELD`
- `ElementType.METHOD`
- `ElementType.ANNOTATION_TYPE`